### PR TITLE
sightscope mode

### DIFF
--- a/sourcefiles/qolhacks.py
+++ b/sourcefiles/qolhacks.py
@@ -1,8 +1,22 @@
+# File for quality of life hacks
 from ctrom import CTRom
 import randosettings as rset
 
-def process_ctrom(ctrom: CTRom, settings: rset.Settings):
+# Trick the game into thinking P1 has the SightScope equipped, for enemy health
+# to always be visible.
+def force_sightscope_on(ctrom: CTRom, settings: rset.Settings):
     if rset.GameFlags.VISIBLE_HEALTH in settings.gameflags:
+        # Seek to the location in the ROM after the game checks if P1's
+        # accessory is a SightScope
         ctrom.rom_data.seek(0x0CF039)
+        # Ignore the result of that comparison and evaluate to always true, by
+        # overwriting the BEQ (branch-if-equal) to BRA (branch-always)
         ctrom.rom_data.write(0x80)
+
+# Testing
+if __name__ == "__main__":
+    ctrom = CTRom.from_file("test1.sfc")
+    settings = rset.Settings.get_new_player_presets()
+    force_sightscope_on(ctrom, settings)
+
 

--- a/sourcefiles/qolhacks.py
+++ b/sourcefiles/qolhacks.py
@@ -13,10 +13,15 @@ def force_sightscope_on(ctrom: CTRom, settings: rset.Settings):
         # overwriting the BEQ (branch-if-equal) to BRA (branch-always)
         ctrom.rom_data.write(0x80)
 
+# After writing additional hacks, put them here. Based on the settings, they
+# will or will not modify the ROM.
+def attempt_all_qol_hacks(ctrom: CTRom, settings: rset.Settings):
+    force_sightscope_on(ctrom, settings)
+
 # Testing
 if __name__ == "__main__":
     ctrom = CTRom.from_file("test1.sfc")
     settings = rset.Settings.get_new_player_presets()
-    force_sightscope_on(ctrom, settings)
+    attempt_all_qol_hacks(ctrom, settings)
 
 

--- a/sourcefiles/qolhacks.py
+++ b/sourcefiles/qolhacks.py
@@ -1,0 +1,8 @@
+from ctrom import CTRom
+import randosettings as rset
+
+def process_ctrom(ctrom: CTRom, settings: rset.Settings):
+    if rset.GameFlags.VISIBLE_HEALTH in settings.gameflags:
+        ctrom.rom_data.seek(0x0CF039)
+        ctrom.rom_data.write(0x80)
+

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -53,7 +53,7 @@ class GameFlags(Flag):
     BOSS_RANDO = auto()
     DUPLICATE_CHARS = auto()
     DUPLICATE_TECHS = auto()
-
+    VISIBLE_HEALTH = auto()
 
 class TabRandoScheme(StrIntEnum):
     UNIFORM = 0
@@ -133,7 +133,8 @@ class Settings:
         ret.gameflags = (GameFlags.FIX_GLITCH |
                          GameFlags.FAST_PENDANT |
                          GameFlags.ZEAL_END |
-                         GameFlags.UNLOCKED_MAGIC)
+                         GameFlags.UNLOCKED_MAGIC |
+                         GameFlags.VISIBLE_HEALTH)
 
         ret.seed = ''
 


### PR DESCRIPTION
this is an initial PR for adding sightscope mode (enemy health always visible) to jets of time

i couldnt test this because ctstrings looks for a huffman_table.pickle file in the pickles directory, which i don't have. but i tested it with the old version of randomizer (you can see that version with my changes in my sightscope-old branch), so i know overwriting the BEQ with BRA does give us the desired effect.

i followed your instructions best i could but as you said, some of the core files are in flux so i couldn't guarantee i could write against them properly, but i did my best. when those things are more solidified i will of course be happy to make any necessary updates and test things on actual roms etc.

i also took the liberty of adding sightscope mode to the new player preset, since i think most of us agreed we would want it at least there.