### PR TITLE
Fix tech order randomization not being passed to randomizer.

### DIFF
--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -322,6 +322,10 @@ class RandoGUI:
         # Shop Prices
         self.settings.shopprices = \
             ShopPrices.inv_str_dict()[self.shop_prices.get()]
+            
+        # Tech randomization
+        self.settings.techorder = \
+            TechOrder.inv_str_dict()[self.tech_order.get()]
 
         # Main flags
         flags = [x for x in list(GameFlags)


### PR DESCRIPTION
Previously, GUI would update displayed choice but not pass to randomizer, causing the default (FULL_RANDOM) to be executed for every seed regardless of setting.

Test procedure:
    Start with master, generate x3 ROMs, one with each tech random setting. They will be identical.
    Repeat with fix. They will not be identical. Spoiler logs show generated tech orders.