### PR TITLE
Add duplicate character and tab ranges to settings spoilers if they've been customized

### DIFF
--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -871,11 +871,32 @@ class Randomizer:
         else:
             json.dump({"configuration": self.config, "settings": self.settings}, outfile, cls=JOTJSONEncoder)
 
+    def _summarize_dupes(self):
+        CharID = ctenums.CharID
+        def summarize_single(choicelist):
+            if len(choicelist) < 4:
+                return "Only " + ", ".join([str(CharID(i)) for i in choicelist])
+            elif len(choicelist) == 7:
+                return "Any"
+            else:
+                return "No " + ", ".join([str(CharID(i)) for i in (set(range(7)) - set(choicelist))])
+
+        chars = {c: summarize_single(self.settings.char_choices[c]) for c in range(len(self.settings.char_choices))}
+        rv = ""
+        for c in sorted(chars.keys()):
+            if chars[c] != "Any":
+                rv = rv + "\n\t" + str(CharID(c)) + ": " + chars[c]
+        return rv
 
     def write_settings_spoilers(self, file_object):
         file_object.write(f"Game Mode: {self.settings.game_mode}\n")
         file_object.write(f"Enemies: {self.settings.enemy_difficulty}\n")
         file_object.write(f"Items: {self.settings.item_difficulty}\n")
+        if self.settings.tab_settings != rset.TabSettings():
+            file_object.write(f"Tabs: Power {self.settings.tab_settings.power_min}-{self.settings.tab_settings.power_max}, Magic {self.settings.tab_settings.magic_min}-{self.settings.tab_settings.magic_max}, Speed {self.settings.tab_settings.speed_min}-{self.settings.tab_settings.speed_max}\n")
+        if rset.GameFlags.DUPLICATE_CHARS in self.settings.gameflags and self.settings.char_choices != rset.Settings().char_choices:
+            dupes = self._summarize_dupes()
+            file_object.write(f"Characters: {dupes}\n")
         file_object.write(f"Techs: {self.settings.techorder}\n")
         file_object.write(f"Shops: {self.settings.shopprices}\n")
         file_object.write(f"Flags: {self.settings.gameflags}\n")


### PR DESCRIPTION
tbh, I mostly want this so this information appears on the web generator share pages, it's hard to distinguish different dc settings from there right now.

if and only if the tab settings have been changed it'll show something like `Tabs: Power 1-4, Magic 1-3, Speed 1-1`

if and only if the dc settings have been changed, it'll show something like:

```
Characters:
        Crono: No Crono
        Lucca: Only Frog, Ayla, Magus
        Ayla: Only Ayla
```

it will only show rows for characters that have restrictions