### PR TITLE
Store the seed hash bytes when generating the ROM

### DIFF
--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -125,6 +125,7 @@ class Randomizer:
         # generate many seeds from it.
         self.base_ctrom = CTRom(rom, ignore_checksum=not is_vanilla)
         self.out_rom: Optional[CTRom] = None
+        self.hash_string_bytes: Optional[bytes] = None
         self.has_generated = False
 
         self.settings = settings
@@ -1110,7 +1111,7 @@ class Randomizer:
         self.out_rom.write_all_scripts_to_rom(clear_scripts=True)
 
         # Put the seed hash on the active/wait screen
-        seedhash.write_hash_string(self.out_rom)
+        self.hash_string_bytes = seedhash.write_hash_string(self.out_rom)
 
         # Apply post-randomization changes
         self.__apply_cosmetic_patches(self.out_rom, self.settings)
@@ -1191,6 +1192,9 @@ class Randomizer:
         return rv
 
     def write_settings_spoilers(self, file_object):
+        if self.hash_string_bytes is not None:
+            hashstr = str(ctstrings.CTNameString(self.hash_string_bytes)).replace('*', '{star}')
+            file_object.write(f"Seed Hash: {hashstr}\n")
         file_object.write(f"Game Mode: {self.settings.game_mode}\n")
         file_object.write(f"Enemies: {self.settings.enemy_difficulty}\n")
         file_object.write(f"Items: {self.settings.item_difficulty}\n")

--- a/sourcefiles/seedhash.py
+++ b/sourcefiles/seedhash.py
@@ -4,9 +4,7 @@ import hashlib
 import ctrom
 import ctstrings
 
-
-def write_hash_string(ct_rom: ctrom.CTRom):
-    ''' Puts a hash string on the active/wait screen of this ctrom.'''
+def calculate_hash_string(ct_rom: ctrom.CTRom) -> bytes:
     rom = ct_rom.rom_data
 
     rom.seek(0)
@@ -26,7 +24,11 @@ def write_hash_string(ct_rom: ctrom.CTRom):
         num, rem = divmod(num, len(symbols))
         hash_string.append(symbols[rem])
 
-    hash_string_b = bytes(hash_string)
+    return bytes(hash_string)
+
+def write_hash_string(ct_rom: ctrom.CTRom) -> bytes:
+    ''' Puts a hash string on the active/wait screen of this ctrom.'''
+    hash_string = calculate_hash_string(ct_rom)
 
     seed_ctstr = ctstrings.CTString.from_str('Seed:')
 
@@ -51,7 +53,7 @@ def write_hash_string(ct_rom: ctrom.CTRom):
         '01'  # next line x 2
         'FF B6 A0 A8 B3'  # (space)Wait
         '02 42 00'  # 2nd line 2nd tile
-        + seed_ctstr.hex() + hash_string_b.hex() +  # Seed string
+        + seed_ctstr.hex() + hash_string.hex() +  # Seed string
         '0A 03'  # Change to page 0x03 (menu stuff)
         '02 00 00'  # Top left
         'AC'  # grey square
@@ -71,6 +73,8 @@ def write_hash_string(ct_rom: ctrom.CTRom):
 
     new_loc = 0x400000 - len(new_menu_script)
 
+    rom = ct_rom.rom_data
+
     rom.seek(0x3FC49F)
     rom.write(int.to_bytes(new_loc & 0xFFFF, 2, 'little'))
 
@@ -86,3 +90,5 @@ def write_hash_string(ct_rom: ctrom.CTRom):
 
     rom.seek(new_hdma_loc)
     rom.write(new_hdma)
+
+    return hash_string


### PR DESCRIPTION
(and write them out in settings spoilers if set)

The other thing this will enable is showing the seed hash in the web generator. Obviously it depends on the ROM having been generated before it can show this, but for all local generation that will have happened; for the web generator, my plan is to store this value in two cases: 1.) when the ROM is generated, if there's nothing stored, put it into the DB, and 2.) when the seed image is generated, if there's nothing there, generate a ROM then just to get this value, and store it; I'll also make sure the seed image is displayed directly on the seed share page, so that there's something asynchronous that forces a generation right away. Once it's stored, it should be possible for us to pull it out to display on the share page, include in web spoiler logs, and put into the seed share images.