### PR TITLE
Minor fixes for CLI arguments

### DIFF
--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -133,7 +133,7 @@ _flag_entry_dict: dict[GF | CF, FlagEntry] = {
         "--add-racelog-spot", None,
         "Gain a KI from the vanilla Race Log chest."),
     GF.SPLIT_ARRIS_DOME: FlagEntry(
-        "--split-arris=dome", None,
+        "--split-arris-dome", None,
         "Get one key item from the dead guy after Guardian.  Get a second "
         "after checking the Arris dome computer and bringing the Seed "
         "(new KI) to Doan."),

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -853,6 +853,7 @@ def get_parser():
     opts_group.add_argument(
         "--battle-speed",
         help="default battle speed (lower is faster)",
+        type=int,
         choices=range(1, 9),
         default=5
     )
@@ -860,6 +861,7 @@ def get_parser():
     opts_group.add_argument(
         "--battle-msg-speed",
         help="default battle message speed (lower is faster)",
+        type=int,
         choices=range(1, 9),
         default=5
     )
@@ -867,6 +869,7 @@ def get_parser():
     opts_group.add_argument(
         "--battle-gauge-style",
         help="default atb gauge style (default 1)",
+        type=int,
         choices=range(3),
         default=1
     )
@@ -874,6 +877,7 @@ def get_parser():
     opts_group.add_argument(
         "--background",
         help="default background (default 1)",
+        type=int,
         choices=range(1, 9),
         default=1
     )

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -487,7 +487,7 @@ def get_parser():
         "balanced - random but biased towards better techs later\n"
         "  random - fully random (default)",
         choices=['normal', 'balanced', 'random'],
-        default='normal',
+        default='random',
         type=str.lower
     )
 


### PR DESCRIPTION
Some minor fixes found using the CLI a bit more.

## Updates

* Fix typo for "--split-arris-dome" flag to CLI
* Fix passing ints for cosmetic options to CLI
* Fix CLI tech-order to default to "random" (instead of "vanilla") as per text says

## Notes

I'm not sure if changing the tech-order in CLI has any repercussions elsewhere, but suspect it doesn't, since "fully random" is the default used in TK GUI as well as web generator.