### PR TITLE
Bugfix: logically require flight for Giant's Claw Rock location

### DIFF
--- a/sourcefiles/logicfactory.py
+++ b/sourcefiles/logicfactory.py
@@ -1063,6 +1063,9 @@ def apply_epoch_fail(game_config: GameConfig):
         flight_tids.append(TID.SUN_KEEP_2300)
         flight_tids.remove(TID.MELCHIOR_KEY)
 
+    if rset.GameFlags.ROCKSANITY in settings.gameflags:
+        flight_tids.append(TID.GIANTS_CLAW_ROCK)
+
     def add_flight(func):
 
         def ret_func(game: Game):


### PR DESCRIPTION
This PR prevents Giant's Claw Rock location from having progression necessary to unlock flight in seeds with Epoch Fail and Rocksanity.

## Updates

* Adds Giant's Claw Rock TID to locations requiring flight for when Epoch Fail is used.

## Context

Was playing a seed with Epoch Fail / Unlocked Skyways and Rocksanity and managed to be logically non-completable because progression necessary to exchange Jets of Time at Blackbird was located in Giant's Claw rock chest (e.g. Gate Key or Bike Key to get to Factory with Johnny Race).

Managed to reproduce issue on beta.ctjot.com with seed: https://beta.ctjot.com/share/t50wzVVWZcSbnh1/

Completion by Spheres shows the issue:

```
0: Obtain Gate Key from Zenan Bridge Key
1: Obtain Tomas Pop from Laruba Rock
2: Obtain C Trigger from Giants Claw Rock
3: Obtain Bike Key from Bekkler Key
4: Obtain Jetsoftime from Lab 32 Race Log
Unlock Flight
```

In above, unlocking flight requires getting the C Trigger at Giants Claw Rock to get the Bike Key at Bekkler to get the Jetsoftime from Lab 32 Race Log, however Giant's Claw requires flight for access.