### PR TITLE
 CLI bugfixes, testing, cleanup prior to adding preset support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,9 +4,6 @@ max-line-length = 119
 
 extend-ignore=
   # Temporarily ignore issues which probably should be addressed in near future
-  ## use isinstance()
-  E721,
-
   ## bare except
   E722,
 

--- a/.flake8
+++ b/.flake8
@@ -4,9 +4,6 @@ max-line-length = 119
 
 extend-ignore=
   # Temporarily ignore issues which probably should be addressed in near future
-  ## bare except
-  E722,
-
   ## imported but unused
   F401,
 

--- a/.flake8
+++ b/.flake8
@@ -7,9 +7,6 @@ extend-ignore=
   ## assigned but never used
   F841,
 
-  ## end-of-file blank lines
-  W391,
-
   # Ignore formatting issues that a tool like black could automatically address
   ## non-syntax indentation (visual)
   E122, E123, E128, E131,
@@ -25,9 +22,6 @@ extend-ignore=
 
   ## trailing whitespace, blank line contains whitespace
   W291, W293,
-
-  ## line breaks around binary operators
-  W503, W504
 
   ## line length
   E501,

--- a/.flake8
+++ b/.flake8
@@ -4,9 +4,6 @@ max-line-length = 119
 
 extend-ignore=
   # Temporarily ignore issues which probably should be addressed in near future
-  ## imported but unused
-  F401,
-
   ## assigned but never used
   F841,
 

--- a/.github/workflows/flake-pytest.yaml
+++ b/.github/workflows/flake-pytest.yaml
@@ -26,4 +26,4 @@ jobs:
       - name: Test with pytest
         run: |
           cd sourcefiles
-          pytest
+          pytest --cov

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
 [tool.black]
 line-length = 119
 skip_string_normalization = true
+
+[tool.mypy]
+disable_error_code = "annotation-unchecked"
+ignore_missing_imports = true
+exclude = [
+  # Some errors on types from tk/ttk in randomizergui.py
+  "^sourcefiles/randomizergui.py",
+
+  # Need to update some type defintions/Optionals in treasures files
+  "^sourcefiles/treasures/",
+
+  # Vanilla Rando code has some missing attributes, might be actual typos/bugs
+  "^sourcefiles/vanillarando/"
+]

--- a/sourcefiles/.coveragerc
+++ b/sourcefiles/.coveragerc
@@ -1,0 +1,18 @@
+[run]
+branch = True
+omit =
+    # omit cached files
+    __pycache__/*
+    .pytest_cache/*
+
+[report]
+exclude_also =
+    # don't complain if tests don't hit defensive code
+    raise AssertionError
+    raise NotImplementedError
+
+    # don't complain about abstract methods, they aren't run
+    @(abc\.)?abstractmethod
+
+    # don't complain about type-checking only code
+    if.*TYPE_CHECKING

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 import argparse
 import copy
 import functools
-import typing
 
 from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Union
 
 import ctstrings
 import ctoptions
@@ -12,15 +12,17 @@ import randosettings as rset
 from randosettings import GameFlags as GF, GameMode as GM, \
     CosmeticFlags as CF
 
+SettingsFlags = Union[rset.GameFlags, rset.CosmeticFlags]
+
 
 @dataclass
 class FlagEntry:
     name: str = ""
-    short_name: typing.Optional[str] = None
-    help_text: typing.Optional[str] = None
+    short_name: Optional[str] = None
+    help_text: Optional[str] = None
 
 
-_flag_entry_dict: dict[GF | CF, FlagEntry] = {
+_flag_entry_dict: Dict[SettingsFlags, FlagEntry] = {
     GF.FIX_GLITCH: FlagEntry(
         "--fix-glitch", "-g",
         "disable save anywhere and HP overflow glitches"),
@@ -219,12 +221,11 @@ _shop_price_dict: dict[str, rset.ShopPrices] = {
 }
 
 def add_flags_to_parser(
-        group_text: typing.Optional[str],
-        flag_list: typing.Iterable[GF | CF],
+        group_text: Optional[str],
+        flag_list: Iterable[GF | CF],
         parser: argparse.ArgumentParser):
 
-    add_target: typing.Union[argparse.ArgumentParser,
-                             argparse._ArgumentGroup]
+    add_target: Union[argparse.ArgumentParser, argparse._ArgumentGroup]
 
     if group_text is None:
         add_target = parser
@@ -234,7 +235,7 @@ def add_flags_to_parser(
 
     for flag in flag_list:
         flag_entry = _flag_entry_dict[flag]
-        add_args: typing.Iterable[str]
+        add_args: Iterable[str]
         if flag_entry.short_name is None:
             add_args = (flag_entry.name,)
         else:

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -86,44 +86,6 @@ def get_ctoptions(args: argparse.Namespace) -> ctoptions.CTOpts:
     return ct_opts
 
 
-_pc_index_dict: dict[str, int] = {
-    'crono': 0,
-    'marle': 1,
-    'lucca': 2,
-    'robo': 3,
-    'frog': 4,
-    'ayla': 5,
-    'magus': 6
-}
-
-_pc_names: list[str] = [
-    'Crono', 'Marle', 'Lucca', 'Robo', 'Frog', 'Ayla', 'Magus', 'Epoch'
-]
-
-
-def get_dc_choices(args: argparse.Namespace) -> list[list[int]]:
-    '''Extract dc-flag settings from argparse.Namespace.'''
-
-    arg_dict = vars(args)
-    def parse_choices(choice_string: str) -> list[int]:
-        choice_string = choice_string.lower()
-
-        if choice_string == 'all':
-            return list(range(7))
-
-        choices = choice_string.split()
-        if choices[0] == 'not':
-            choices = choices[1:]
-            choice_ints = [_pc_index_dict[choice] for choice in choices]
-            return [ind for ind in range(7) if ind not in choice_ints]
-        else:
-            choice_ints = [_pc_index_dict[choice] for choice in choices]
-            return [ind for ind in range(7) if ind in choice_ints]
-
-    namespace_vars = [name + '_choices' for name in _pc_index_dict]
-    return [parse_choices(arg_dict[name]) for name in namespace_vars]
-
-
 def get_mystery_settings(args: argparse.Namespace) -> rset.MysterySettings:
     mset = rset.MysterySettings()
     val_dict = vars(args)
@@ -170,8 +132,6 @@ def get_mystery_settings(args: argparse.Namespace) -> rset.MysterySettings:
 def args_to_settings(args: argparse.Namespace) -> rset.Settings:
     '''Convert result of argparse to settings object.'''
 
-    val_dict = vars(args)
-
     ret_set = rset.Settings()
     ret_set.seed = args.seed
     ret_set.game_mode = adp.GameModeAdapter.to_setting(args)
@@ -184,9 +144,7 @@ def args_to_settings(args: argparse.Namespace) -> rset.Settings:
     ret_set.mystery_settings = get_mystery_settings(args)
     ret_set.cosmetic_flags = adp.CosmeticFlagsAdapter.to_setting(args)
     ret_set.ctoptions = get_ctoptions(args)
-    ret_set.char_names = [
-        val_dict[name.lower()+"_name"] for name in _pc_names
-    ]
+    ret_set.char_settings = adp.CharSettingsAdapter.to_setting(args)
 
     return ret_set
 
@@ -619,7 +577,7 @@ def get_parser():
         return string
 
     name_group = parser.add_argument_group("Character Names")
-    for char_name in _pc_names:
+    for char_name in rset.CharNames.default():
         name_group.add_argument(
             f"--{char_name.lower()}-name",
             type=verify_name,

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -5,6 +5,7 @@ import functools
 import operator
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Union
 
 import ctstrings
@@ -424,11 +425,14 @@ def add_generation_options(parser: argparse.ArgumentParser):
     gen_group.add_argument(
         "--input-file", "-i",
         required=True,
-        help="path to Chrono Trigger (U) rom")
+        help="path to Chrono Trigger (U) rom",
+        type=Path,
+    )
 
     gen_group.add_argument(
         "--output-path", "-o",
-        help="path to output directory (default same as input)"
+        help="path to output directory (default same as input)",
+        type=Path,
     )
 
     gen_group.add_argument(

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -1,226 +1,18 @@
 from __future__ import annotations
 import argparse
 import copy
-import functools
-import operator
 
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional, Union
+from typing import Iterable, Optional, Union
 
+import cli.adapters as adp
 import ctstrings
 import ctoptions
 import randosettings as rset
-from randosettings import GameFlags as GF, GameMode as GM, \
-    CosmeticFlags as CF
 
-SettingsFlags = Union[rset.GameFlags, rset.CosmeticFlags]
+from cli.constants import FLAG_ENTRY_DICT, MYSTERY_FLAG_PROB_ENTRIES
+from randosettings import GameFlags as GF, GameMode as GM, CosmeticFlags as CF
 
-
-@dataclass
-class FlagEntry:
-    name: str = ""
-    short_name: Optional[str] = None
-    help_text: Optional[str] = None
-
-
-_flag_entry_dict: Dict[SettingsFlags, FlagEntry] = {
-    GF.FIX_GLITCH: FlagEntry(
-        "--fix-glitch", "-g",
-        "disable save anywhere and HP overflow glitches"),
-    GF.BOSS_SCALE: FlagEntry(
-        "--boss-scale", "-b",
-        "scale bosses based on key-item locations"),
-    GF.ZEAL_END: FlagEntry(
-        "--zeal-end", "-z",
-        "allow the game to be won when Zeal is defeated in the "
-        "Black Omen"),
-    GF.FAST_PENDANT: FlagEntry(
-        "--fast-pendant", "-p",
-        "the pendant will be charged when 2300 is reached"),
-    GF.LOCKED_CHARS: FlagEntry(
-        "--locked-chars", "-c",
-        "require dreamstone for the dactyl character and factory for "
-        "the Proto Dome character"),
-    GF.UNLOCKED_MAGIC: FlagEntry(
-        "--unlocked-magic", "-m",
-        "magic is unlocked from the beginning of the game without "
-        "visiting Spekkio"),
-    GF.CHRONOSANITY: FlagEntry(
-        "--chronosanity", "-cr",
-        "key items may be found in treasure chests"),
-    GF.ROCKSANITY: FlagEntry(
-        "--rocksanity", None,
-        "rocks are added as key items and key items may be found "
-        "in rock locations"),
-    GF.TAB_TREASURES: FlagEntry(
-        "--tab-treasures", None,
-        "all treasure chests contain tabs"),
-    GF.BOSS_RANDO: FlagEntry(
-        "--boss-randomization", "-ro",
-        "randomize the location of bosses and scale based on location"),
-    GF.CHAR_RANDO: FlagEntry(
-        "--char-rando", "-rc",
-        "randomize character identities and models"), 
-    GF.DUPLICATE_CHARS: FlagEntry(
-        "--duplicate-characters", "-dc",
-        "allow multiple copies of a character to be present in a seed"),
-    GF.DUPLICATE_TECHS: FlagEntry(
-        "--duplicate-techs", None,
-        "allow duplicate characters to perform dual techs together"),
-    GF.VISIBLE_HEALTH: FlagEntry(
-        "--visible-health", None,
-        "the sightscope effect will always be present"),
-    GF.FAST_TABS: FlagEntry(
-        "--fast-tabs", None,
-        "picking up a tab will not pause movement for the fanfare"),
-    GF.BUCKET_LIST: FlagEntry(
-        "--bucket-list", "-k",
-        "allow the End of Time bucket to Lavos to activate when enough "
-        "objectives have been completed."),
-    GF.TECH_DAMAGE_RANDO: FlagEntry(
-        "--tech-damage-rando", None,
-        "Randomize the damage dealt by single techs."),
-    GF.MYSTERY: FlagEntry(
-        "--mystery", None,
-        "choose flags randomly according to mystery settings"),
-    GF.BOSS_SIGHTSCOPE: FlagEntry(
-        "--boss-sightscope", None,
-        "allow the sightscope to work on bosses"),
-    GF.USE_ANTILIFE: FlagEntry(
-        "--use-antilife", None,
-        "use Anti-Life instead of Black Hole for Magus"),
-    GF.TACKLE_EFFECTS_ON: FlagEntry(
-        "--tackle-on-hit-effects", None,
-        "allow Robo Tackle to use the on-hit effects of Robo's weapons"),
-    GF.HEALING_ITEM_RANDO: FlagEntry(
-        "--healing-item-rando", "-he",
-        "randomizes effects of healing items"),
-    GF.FREE_MENU_GLITCH: FlagEntry(
-        "--free-menu-glitch", None,
-        "provides a longer window to enter the menu prior to Lavos3 and "
-        "Zeal2"),
-    GF.GEAR_RANDO: FlagEntry(
-        "--gear-rando", "-q",
-        "randomizes effects on weapons, armors, and accessories"),
-    GF.STARTERS_SUFFICIENT: FlagEntry(
-        "--starters-sufficient", None,
-        "go mode will be acheivable without recruiting additional "
-        "characters"),
-    GF.EPOCH_FAIL: FlagEntry(
-        "--epoch-fail", "-ef",
-        "Epoch flight must be unlocked by bringing the JetsOfTime to "
-        "Dalton in the Snail Stop"),
-    GF.BOSS_SPOT_HP: FlagEntry(
-        "--boss-spot-hp",
-        "boss HP is set to match the vanilla boss HP in each spot"),
-    # Logic Tweak flags from VanillaRando mode
-    GF.UNLOCKED_SKYGATES: FlagEntry(
-        "--unlocked-skyways", None,
-        "Skyways are available as soon as 12kBC is. Normal go mode is still "
-        "needed to unlock the Ocean Palace."),
-    GF.ADD_SUNKEEP_SPOT: FlagEntry(
-        "--add-sunkeep-spot", None,
-        "Adds Sun Stone as an independent key item.  Moonstone charges to a "
-        "random item"),
-    GF.ADD_BEKKLER_SPOT: FlagEntry(
-        "--add-bekkler-spot", None,
-        "C.Trigger unlocks clone game for a KI"),
-    GF.ADD_CYRUS_SPOT: FlagEntry(
-        "--add-cyrus-spot", None,
-        "Gain a KI from Cyrus's Grave w/ Frog.  No Frog stat boost."),
-    GF.RESTORE_TOOLS: FlagEntry(
-        "--restore-tools", None,
-        "Adds Tools. Tools will fix Norther Ruins."),
-    GF.ADD_OZZIE_SPOT: FlagEntry(
-        "--add-ozzie-spot", None, "Gain a KI after Ozzie's Fort."),
-    GF.RESTORE_JOHNNY_RACE: FlagEntry(
-        "--restore-johnny-race", None,
-        "Add bike key and Johnny Race. Bike Key is required to cross Lab32."),
-    GF.ADD_RACELOG_SPOT: FlagEntry(
-        "--add-racelog-spot", None,
-        "Gain a KI from the vanilla Race Log chest."),
-    GF.REMOVE_BLACK_OMEN_SPOT: FlagEntry(
-        "--remove-black-omen-spot", None,
-        "Removes Black Omen rock chest being a possible KI."),
-    GF.SPLIT_ARRIS_DOME: FlagEntry(
-        "--split-arris-dome", None,
-        "Get one key item from the dead guy after Guardian.  Get a second "
-        "after checking the Arris dome computer and bringing the Seed "
-        "(new KI) to Doan."),
-    GF.VANILLA_ROBO_RIBBON: FlagEntry(
-        "--vanilla-robo-ribbon", None,
-        "Gain Robo stat boost from defeating AtroposXR.  If no Atropos in "
-        "seed, then gain from Geno Dome."),
-    GF.VANILLA_DESERT: FlagEntry(
-        "--vanilla-desert", None,
-        "The sunken desert only unlocks after talking to the plant lady "
-        "in Zeal"),
-    # Cosmetic Flags
-    CF.AUTORUN: FlagEntry(
-        "--autorun", None,
-        "Automatically run.  Push run button to walk."
-    ),
-    CF.DEATH_PEAK_ALT_MUSIC: FlagEntry(
-        "--death-peak-alt-music", None,
-        "use Singing Mountain track on Death Peak"
-    ),
-    CF.ZENAN_ALT_MUSIC: FlagEntry(
-        "--zenan-alt-music", None,
-        "use alt battle theme for Zenan Bridge"
-    ),
-    CF.QUIET_MODE: FlagEntry(
-        "--quiet", None,
-        "disable all music (not sound effects)"
-    ),
-    CF.REDUCE_FLASH: FlagEntry(
-        "--reduce-flashes", None,
-        "disable most flashing effects"
-    )
-}
-
-#flag, name, default
-_mystery_flag_prob_entries = [
-    (GF.TAB_TREASURES, "flag_tab_treasures", 0.10),
-    (GF.UNLOCKED_MAGIC, "flag_unlocked_magic", 0.50),
-    (GF.BUCKET_LIST, "flag_bucket_list", 0.15),
-    (GF.CHRONOSANITY, "flag_chronosanity", 0.30),
-    (GF.BOSS_RANDO, "flag_boss_rando", 0.50),
-    (GF.BOSS_SCALE, "flag_boss_scaling", 0.30),
-    (GF.LOCKED_CHARS, "flag_locked_chars", 0.25),
-    (GF.CHAR_RANDO, "flag_char_rando", 0.5),
-    (GF.DUPLICATE_CHARS, "flag_duplicate_chars", 0.25),
-    (GF.EPOCH_FAIL, "flag_epoch_fail", 0.50),
-    (GF.GEAR_RANDO, "flag_gear_rando", 0.25),
-    (GF.HEALING_ITEM_RANDO, "flag_heal_rando", 0.25),
-]
-
-_mode_dict: dict[str, GM] = {
-    'std': GM.STANDARD,
-    'lw': GM.LOST_WORLDS,
-    'loc': GM.LEGACY_OF_CYRUS,
-    'ia': GM.ICE_AGE,
-    'van': GM.VANILLA_RANDO
-}
-
-_diff_dict: dict[str, rset.Difficulty] = {
-    'easy': rset.Difficulty.EASY,
-    'normal': rset.Difficulty.NORMAL,
-    'hard': rset.Difficulty.HARD
-}
-
-_tech_order_dict: dict[str, rset.TechOrder] = {
-    'normal': rset.TechOrder.NORMAL,
-    'balanced': rset.TechOrder.BALANCED_RANDOM,
-    'random': rset.TechOrder.FULL_RANDOM
-}
-
-_shop_price_dict: dict[str, rset.ShopPrices] = {
-    'normal': rset.ShopPrices.NORMAL,
-    'random': rset.ShopPrices.FULLY_RANDOM,
-    'mostrandom': rset.ShopPrices.MOSTLY_RANDOM,
-    'free': rset.ShopPrices.FREE
-}
 
 def add_flags_to_parser(
         group_text: Optional[str],
@@ -236,7 +28,7 @@ def add_flags_to_parser(
         add_target = group
 
     for flag in flag_list:
-        flag_entry = _flag_entry_dict[flag]
+        flag_entry = FLAG_ENTRY_DICT[flag]
         add_args: Iterable[str]
         if flag_entry.short_name is None:
             add_args = (flag_entry.name,)
@@ -247,10 +39,6 @@ def add_flags_to_parser(
             help=flag_entry.help_text,
             action="store_true"
         )
-
-def flag_name_to_namespace_key(flag_name: str):
-    return flag_name[2:].replace('-', '_')
-
 
 # https://stackoverflow.com/questions/3853722/
 # how-to-insert-newlines-on-argparse-help-text
@@ -281,6 +69,21 @@ def get_bucket_settings(args: argparse.Namespace) -> rset.BucketSettings:
         disable_other_go_modes, objectives_win, num_objectives,
         num_objectives_needed, obj_strs
     )
+
+
+def get_ctoptions(args: argparse.Namespace) -> ctoptions.CTOpts:
+    '''Extract CTOpts from argparse.Namespace.'''
+    ct_opts = ctoptions.CTOpts()
+    ct_opts.save_menu_cursor = args.save_menu_cursor
+    ct_opts.save_battle_cursor = args.save_battle_cursor
+    ct_opts.save_tech_cursor = not args.save_skill_cursor_off
+    ct_opts.skill_item_info = not args.skill_item_info_off
+    ct_opts.consistent_paging = args.consistent_paging
+    ct_opts.battle_speed = args.battle_speed - 1
+    ct_opts.battle_msg_speed = args.battle_msg_speed - 1
+    ct_opts.battle_gauge_style = args.battle_gauge_style
+    ct_opts.menu_background = args.background - 1
+    return ct_opts
 
 
 _pc_index_dict: dict[str, int] = {
@@ -357,60 +160,30 @@ def get_mystery_settings(args: argparse.Namespace) -> rset.MysterySettings:
     }
 
     mset.flag_prob_dict = {
-        flag: val_dict['mystery_'+name]
-        for flag, name, _ in _mystery_flag_prob_entries
+        flag: getattr(args, f"mystery_{name}")
+        for flag, name, _ in MYSTERY_FLAG_PROB_ENTRIES
     }
 
     return mset
 
-def fill_flags(val_dict: Dict[str, Any], init: SettingsFlags) -> SettingsFlags:
-    cls = type(init)
-    return functools.reduce(
-        operator.or_,
-        (flag for (flag, entry) in _flag_entry_dict.items()
-         if isinstance(flag, cls)
-         and val_dict[flag_name_to_namespace_key(entry.name)] is True),
-        init
-    )
 
 def args_to_settings(args: argparse.Namespace) -> rset.Settings:
     '''Convert result of argparse to settings object.'''
 
     val_dict = vars(args)
-    flags = rset.GameFlags(fill_flags(val_dict, GF(0)))
-
-    mode = _mode_dict[val_dict['mode']]
-    item_difficulty = _diff_dict[val_dict['item_difficulty']]
-    enemy_difficulty = _diff_dict[val_dict['enemy_difficulty']]
-    tech_order = _tech_order_dict[val_dict['tech_order']]
 
     ret_set = rset.Settings()
-    ret_set.seed = val_dict['seed']
-    ret_set.game_mode = mode
-    ret_set.gameflags = flags
-    ret_set.initial_flags = copy.deepcopy(flags)
-    ret_set.item_difficulty = item_difficulty
-    ret_set.enemy_difficulty = enemy_difficulty
-    ret_set.techorder = tech_order
-
+    ret_set.seed = args.seed
+    ret_set.game_mode = adp.GameModeAdapter.to_setting(args)
+    ret_set.gameflags = adp.GameFlagsAdapter.to_setting(args)
+    ret_set.initial_flags = copy.deepcopy(ret_set.gameflags)
+    ret_set.item_difficulty =  adp.ItemDifficultyAdapter.to_setting(args)
+    ret_set.enemy_difficulty =  adp.EnemyDifficultyAdapter.to_setting(args)
+    ret_set.techorder = adp.TechOrderAdapter.to_setting(args)
+    ret_set.shopprices = adp.ShopPricesAdapter.to_setting(args)
     ret_set.mystery_settings = get_mystery_settings(args)
-    
-    cos_flags = rset.CosmeticFlags(fill_flags(val_dict, CF(0)))
-
-    ct_opts = ctoptions.CTOpts()
-    ct_opts.save_menu_cursor = val_dict['save_menu_cursor']
-    ct_opts.save_battle_cursor = val_dict['save_battle_cursor']
-    ct_opts.save_tech_cursor = not val_dict['save_skill_cursor_off']
-    ct_opts.skill_item_info = not val_dict['skill_item_info_off']
-    ct_opts.consistent_paging = val_dict['consistent_paging']
-    ct_opts.battle_speed = val_dict['battle_speed']
-    ct_opts.battle_msg_speed = val_dict['battle_msg_speed']-1
-    ct_opts.battle_gauge_style = val_dict['battle_gauge_style']
-    ct_opts.menu_background = val_dict['background']-1
-
-    ret_set.cosmetic_flags = cos_flags
-    ret_set.ctoptions = ct_opts
-
+    ret_set.cosmetic_flags = adp.CosmeticFlagsAdapter.to_setting(args)
+    ret_set.ctoptions = get_ctoptions(args)
     ret_set.char_names = [
         val_dict[name.lower()+"_name"] for name in _pc_names
     ]
@@ -458,6 +231,8 @@ def get_parser():
 
     add_generation_options(parser)
 
+    # arguments with a default of "argparse.SUPPRESS", when explicitly specified
+    # on the CLI, will override any other value (e.g. from a preset file)
     parser.add_argument(
         "--mode",
         choices=['std', 'lw', 'ia', 'loc', 'van'],
@@ -468,7 +243,7 @@ def get_parser():
         "  ia: ice age\n"
         " loc: legacy of cyrus\n"
         " van: vanilla rando",
-        default='std',
+        default=argparse.SUPPRESS,
         type=str.lower
     )
 
@@ -477,7 +252,7 @@ def get_parser():
         help="controls quality of treasure, drops, and starting gold "
         "(default: normal)",
         choices=['easy','normal', 'hard'],
-        default='normal',
+        default=argparse.SUPPRESS,
         type=str.lower
     )
 
@@ -486,7 +261,7 @@ def get_parser():
         help="controls strength of enemies and xp/tp rewards "
         "(default: normal)",
         choices=['normal', 'hard'],
-        default='normal',
+        default=argparse.SUPPRESS,
         type=str.lower
     )
 
@@ -498,12 +273,12 @@ def get_parser():
         "balanced - random but biased towards better techs later\n"
         "  random - fully random (default)",
         choices=['normal', 'balanced', 'random'],
-        default='random',
+        default=argparse.SUPPRESS,
         type=str.lower
     )
 
     parser.add_argument(
-        "--shop_prices",
+        "--shop-prices",
         help="R|"
         "controls the prices in shops\n"
         "    normal - standard prices (default)\n"
@@ -511,7 +286,7 @@ def get_parser():
         "mostrandom - random except for staple consumables\n"
         "      free - all items cost 1G",
         choices=['normal', 'random', 'mostrandom', 'free'],
-        default='normal',
+        default=argparse.SUPPRESS,
         type=str.lower
     )
 
@@ -814,7 +589,7 @@ def get_parser():
 
         return fval
 
-    for _, flag_str, prob in _mystery_flag_prob_entries:
+    for _, flag_str, prob in MYSTERY_FLAG_PROB_ENTRIES:
         mystery_flags.add_argument(
             "--mystery_"+flag_str,
             type=check_prob,

--- a/sourcefiles/arguments.py
+++ b/sourcefiles/arguments.py
@@ -6,7 +6,6 @@ import typing
 
 from dataclasses import dataclass
 
-import ctenums
 import ctstrings
 import ctoptions
 import randosettings as rset

--- a/sourcefiles/asm/assemble.py
+++ b/sourcefiles/asm/assemble.py
@@ -8,7 +8,6 @@ from typing import Union, List
 from asm import instructions as inst
 from asm.instructions import _BranchInstruction, _NormalInstruction
 
-import byteops
 
 Instruction = Union[_BranchInstruction, _NormalInstruction]
 ASMList = List[Union[Instruction, str]]

--- a/sourcefiles/bossrandoevent.py
+++ b/sourcefiles/bossrandoevent.py
@@ -184,7 +184,8 @@ def get_random_assignment(
         ) -> dict[bt.BossSpotID, bt.BossID]:
 
     if len(spots) > len(bosses):
-        raise InsufficientSpotsException
+        err = f"Not enough bosses for spots: {len(spots)} spots > {len(bosses)} bosses"
+        raise InsufficientSpotsException(err)
 
     random.shuffle(bosses)
 

--- a/sourcefiles/bossrandoevent.py
+++ b/sourcefiles/bossrandoevent.py
@@ -159,7 +159,7 @@ def set_twin_boss_data_in_config(one_spot_boss: bt.BossID,
         settings.game_mode
     )[EnemyID.TWIN_BOSS]
 
-    if rset.GameFlags.BOSS_SPOT_HP in settings.gameflags:
+    if rset.ROFlags.BOSS_SPOT_HP in settings.ro_settings.flags:
         scaled_stats.hp = twin_stats.hp
 
     config.enemy_dict[EnemyID.TWIN_BOSS] = scaled_stats
@@ -534,7 +534,7 @@ def scale_bosses_given_assignment(settings: rset.Settings,
         )
 
         bossspot.distribute_rewards(reward_dict[spot], to_scheme, scaled_stats)
-        if rset.GameFlags.BOSS_SPOT_HP in settings.gameflags:
+        if rset.ROFlags.BOSS_SPOT_HP in settings.ro_settings.flags:
             bossspot.distribute_hp(
                 from_scheme, to_scheme, hp_dict, scaled_stats
             )

--- a/sourcefiles/bucketfragment.py
+++ b/sourcefiles/bucketfragment.py
@@ -11,13 +11,18 @@ import randoconfig as cfg
 import xpscale
 
 
+# TODO: there are no references to this function in the codebase
+# might be WIP or could be something to remove
 def set_bucket_function(ctrom: CTRom, settings: rset.Settings):
     script_man = ctrom.script_manager
     eot_script = script_man.get_script(ctenums.LocID.END_OF_TIME)
 
     new_eot_script = ctevent.Event.from_flux('./flux/bucket_eot.Flux')
 
-    num_fragments = settings.bucket_settings.needed_fragments
+    # TODO: below is only reference to "needed_fragements" in codebase
+    # not sure what it should default to but that should be updated in randosettings
+    # if this should be used
+    num_fragments = getattr(settings.bucket_settings, 'needed_fragments', 0)
 
     start = new_eot_script.get_function_start(0x09, 1)
     end = new_eot_script.get_function_end(0x09, 1)

--- a/sourcefiles/bucketgui.py
+++ b/sourcefiles/bucketgui.py
@@ -5,96 +5,14 @@ Module for creating a frame with bucket settings.
 import tkinter as tk
 import typing
 
+from collections import OrderedDict
+
 import objectivehints as oh
 import randosettings as rset
 
 
-# Build a list of preset objective hint strings with the more common random
-# categories at the top
-_objective_preset_dict: dict[str, str] = {
-    'Random': '65:quest_gated, 30:boss_nogo, 15:recruit_gated',
-    'Random Gated Quest': 'quest_gated',
-    'Random Hard Quest': 'quest_late',
-    'Random Go Mode Quest': 'quest_go',
-    'Random Gated Character Recruit': 'recruit_gated',
-    'Random Boss (Includes Go Mode Dungeons)': 'boss_any',
-    'Random Boss from Go Mode Dungeon': 'boss_go',
-    'Random Boss (No Go Mode Dungeons)': 'boss_nogo',
-    'Recruit 3 Characters (Total 5)': 'recruit_3',
-    'Recruit 4 Characters (Total 6)': 'recruit_4',
-    'Recruit 5 Characters (Total 7)': 'recruit_5',
-    'Collect 10 of 20 Fragments': 'collect_fragments_10_10',
-    'Collect 10 of 30 Fragments': 'collect_fragments_10_20',
-    'Collect 3 Rocks': 'collect_rocks_3',
-    'Collect 4 Rocks': 'collect_rocks_4',
-    'Collect 5 Rocks': 'collect_rocks_5',
-    'Forge the Masamune': 'quest_forge',
-    'Charge the Moonstone': 'quest_moonstone',
-    'Trade the Jerky Away': 'quest_jerky',
-    'Defeat the Arris Dome Boss': 'quest_arris',
-    'Visit Cyrus\'s Grave with Frog': 'quest_cyrus',
-    'Defeat the Boss of Death\'s Peak': 'quest_deathpeak',
-    'Defeat the Boss of Denadoro Mountains': 'quest_denadoro',
-    'Gain Epoch Flight': 'quest_epoch',
-    'Defeat the Boss of the Factory Ruins': 'quest_factory',
-    'Defeat the Boss of the Geno Dome': 'quest_geno',
-    'Defeat the Boss of the Giant\'s Claw': 'quest_claw',
-    'Defeat the Boss of Heckran\'s Cave': 'quest_heckran',
-    'Defeat the Boss of the King\'s Trial': 'quest_shard',
-    'Defeat the Boss of Manoria Cathedral': 'quest_cathedral',
-    'Defeat the Boss of Mount Woe': 'quest_woe',
-    'Defeat the Boss of the Pendant Trial': 'quest_pendant',
-    'Defeat the Boss of the Reptite Lair': 'quest_reptite',
-    'Defeat the Boss of the Sun Palace': 'quest_sunpalace',
-    'Defeat the Boss of the Sunken Desert': 'quest_desert',
-    'Defeat the Boss in the Zeal Throneroom': 'quest_zealthrone',
-    'Defeat the Boss of Zenan Bridge': 'quest_zenan',
-    'Defeat the Black Tyrano': 'quest_blacktyrano',
-    'Defeat the Tyrano Lair Midboss': 'quest_tyranomid',
-    'Defeat the Boss in Flea\'s Spot': 'quest_flea',
-    'Defeat the Boss in Slash\'s Spot': 'quest_slash',
-    'Defeat Magus in Magus\'s Castle': 'quest_magus',
-    'Defeat the Boss in the GigaMutant Spot': 'quest_omengiga',
-    'Defeat the Boss in the TerraMutant Spot': 'quest_omenterra',
-    'Defeat the Boss in the ElderSpawn Spot': 'quest_omenelder',
-    'Defeat the Boss in the Twin Golem Spot': 'quest_twinboss',
-    'Beat Johnny in a Race': 'quest_johnny',
-    'Bet on a Fair Race and Win': 'quest_fairrace',
-    'Play the Fair Drinking Game': 'quest_soda',
-    'Defeat AtroposXR': 'boss_atropos',
-    'Defeat DaltonPlus': 'boss_dalton',
-    'Defeat DragonTank': 'boss_dragontank',
-    'Defeat ElderSpawn': 'boss_elderspawn',
-    'Defeat Flea': 'boss_flea',
-    'Defeat Flea Plus': 'boss_fleaplus',
-    'Defeat Giga Gaia': 'boss_gigagaia',
-    'Defeat GigaMutant': 'boss_gigamutant',
-    'Defeat Golem': 'boss_golem',
-    'Defeat Golem Boss': 'boss_golemboss',
-    'Defeat Guardian': 'boss_guardian',
-    'Defeat Heckran': 'boss_heckran',
-    'Defeat LavosSpawn': 'boss_lavosspawn',
-    'Defeat Magus (North Cape)': 'boss_magusnc',
-    'Defeat Masamune': 'boss_masamune',
-    'Defeat Mother Brain': 'boss_motherbrain',
-    'Defeat Mud Imp': 'boss_mudimp',
-    'Defeat Nizbel': 'boss_nizbel',
-    'Defeat Nizbel II': 'boss_nizbel2',
-    'Defeat R-Series': 'boss_rseries',
-    'Defeat Retinite': 'boss_retinite',
-    'Defeat RustTyrano': 'boss_rusttyrano',
-    'Defeat Slash': 'boss_slash',
-    'Defeat Son of Sun': 'boss_sonofsun',
-    'Defeat Super Slash': 'boss_superslash',
-    'Defeat TerraMutant': 'boss_terramutant',
-    # Skip twinboss b/c it's in quests
-    'Defeat Yakra': 'boss_yakra',
-    'Defeat Yakra XIII': 'boss_yakraxiii',
-    'Defeat Zombor': 'boss_zombor'
-}
-
-
 class BucketPage(tk.Frame):
+    _obhint_aliases: OrderedDict[str, str] = oh.get_objective_hint_aliases()
 
     def __init__(self, *args, **kwargs):
         tk.Frame.__init__(self, *args, **kwargs)
@@ -153,7 +71,7 @@ class BucketPage(tk.Frame):
             tk.Label(frame, text=f'Obj {ind+1}:').pack(side=tk.LEFT)
             option = tk.ttk.Combobox(
                 frame,
-                values=list(_objective_preset_dict.keys()),
+                values=list(self._obhint_aliases.keys()),
                 textvariable=self.simple_mode_choices[ind]
             )
 
@@ -240,7 +158,7 @@ class BucketPage(tk.Frame):
         value = event.widget.get()
 
         if value == '':
-            event.widget.configure(values=list(_objective_preset_dict.keys()))
+            event.widget.configure(values=list(self._obhint_aliases.keys()))
         else:
             cur_values = event.widget.cget('values')
             cur_values = [
@@ -250,8 +168,8 @@ class BucketPage(tk.Frame):
             event.widget.configure(values=cur_values)
 
         label = self.simple_mode_hint_labels[index]
-        if value in _objective_preset_dict:
-            label['text'] = _objective_preset_dict[value]
+        if value in self._obhint_aliases:
+            label['text'] = self._obhint_aliases[value]
         else:
             label['text'] = ''
 
@@ -285,8 +203,8 @@ class BucketPage(tk.Frame):
                     break
 
                 value = combobox.get()
-                if value in _objective_preset_dict:
-                    ret.hints[ind] = _objective_preset_dict[value]
+                if value in self._obhint_aliases:
+                    ret.hints[ind] = self._obhint_aliases[value]
                 else:
                     ret.hints[ind] = value
 
@@ -302,7 +220,7 @@ class BucketPage(tk.Frame):
 
         for ind, hint in enumerate(bs.hints):
             match = [
-                (name, code) for name, code in _objective_preset_dict.items()
+                (name, code) for name, code in self._obhint_aliases.items()
                 if code == hint.lower()
             ]
 

--- a/sourcefiles/bucketgui.py
+++ b/sourcefiles/bucketgui.py
@@ -2,7 +2,6 @@
 Module for creating a frame with bucket settings.
 '''
 
-import dataclasses
 import tkinter as tk
 import typing
 

--- a/sourcefiles/bucketgui.py
+++ b/sourcefiles/bucketgui.py
@@ -236,7 +236,7 @@ class BucketPage(tk.Frame):
 
     # https://stackoverflow.com/questions/55649709/
     # is-autocomplete-search-feature-available-in-tkinter-combo-box
-    def check_combobox_input(self, event, index: int = None):
+    def check_combobox_input(self, event, index: typing.Optional[int] = None):
         value = event.widget.get()
 
         if value == '':

--- a/sourcefiles/bucketlist.py
+++ b/sourcefiles/bucketlist.py
@@ -11,20 +11,14 @@ from common import distribution
 import ctenums
 import ctrom
 
-import eventcommand
 from eventcommand import EventCommand as EC, Operation as OP, FuncSync as FS
-
-import eventfunction
 from eventfunction import EventFunction as EF
-
 from maps import locationtypes
 
 import objectivehints as obhint
 import objectivetypes as oty
-
 import randoconfig as cfg
 import randosettings as rset
-
 import xpscale
 
 

--- a/sourcefiles/bucketlist.py
+++ b/sourcefiles/bucketlist.py
@@ -202,11 +202,11 @@ def add_objectives_to_config(settings: rset.Settings,
                                      objective_pool[ind])
         objectives.append(objective)
 
-        if type(chosen_key) == str:
+        if isinstance(chosen_key, str):
             chosen_key = chosen_key.split('_')[0]
         used_keys.append(chosen_key)
 
-        if type(chosen_key) == ctenums.CharID:
+        if isinstance(chosen_key, ctenums.CharID):
             used_keys.append('recruits')
 
     for objective in objectives:
@@ -228,7 +228,7 @@ def clean_distribution(dist: distribution.Distribution,
     for weight, items in wo_pairs:
         for key in used_keys:
             if key in ('fragments', 'rocks', 'recruits'):
-                str_keys = [x for x in items if type(x) == str]
+                str_keys = [x for x in items if isinstance(x, str)]
                 match_keys = [x for x in str_keys if key in x]
                 for key in match_keys:
                     items.remove(key)
@@ -244,18 +244,18 @@ def clean_distribution(dist: distribution.Distribution,
 def get_obj_from_key(key, settings: rset.Settings,
                      config: cfg.RandoConfig,
                      item_id: ctenums.ItemID):
-    if type(key) == rotypes.BossID:
+    if isinstance(key, rotypes.BossID):
         return oty.get_defeat_boss_obj(key, settings,
                                        config.boss_assign_dict, item_id)
-    if type(key) == oty.QuestID:
+    if isinstance(key, oty.QuestID):
         return oty.get_quest_obj(key, settings, item_id)
-    if type(key) == ctenums.RecruitID:
+    if isinstance(key, ctenums.RecruitID):
         return oty.get_recruit_spot_obj(key, settings,
                                         config.char_assign_dict, item_id)
-    if type(key) == ctenums.CharID:
+    if isinstance(key, ctenums.CharID):
         return oty.get_recruit_char_obj(key, settings,
                                         config.char_assign_dict, item_id)
-    if type(key) == str:
+    if isinstance(key, str):
         parts = key.split('_')
         if parts[0] == 'rocks':
             num_rocks = int(parts[1])

--- a/sourcefiles/bucketlist.py
+++ b/sourcefiles/bucketlist.py
@@ -128,7 +128,7 @@ def add_objectives_to_config(settings: rset.Settings,
     rem_objs.secondary_stats.is_key_item = True
 
     num_objs = settings.bucket_settings.num_objectives
-    hints = list(settings.bucket_settings.hints)
+    hints = obhint.normalize_objectives_from_hints(settings.bucket_settings.hints)
 
     KeyType = typing.Union[oty.QuestID, ctenums.RecruitID,
                            rotypes.BossID, str]

--- a/sourcefiles/characters/ctpcstats.py
+++ b/sourcefiles/characters/ctpcstats.py
@@ -10,7 +10,6 @@ import itemdata
 import ctenums
 import ctrom
 import cttypes as ctt
-import ctstrings
 
 
 class PCStat(ctenums.StrIntEnum):

--- a/sourcefiles/characters/ctpcstats.py
+++ b/sourcefiles/characters/ctpcstats.py
@@ -354,7 +354,7 @@ class PCStatData:
         self.tech_level = TechLevel(tech_level)
         self.tp_threshholds = TPThresholds(tp_threshholds)
 
-    def _jot_json(self):
+    def to_jot_json(self):
         # Copying from the old statcompute.py
         stats = {
             'max_hp': self.stat_block.max_hp,
@@ -487,9 +487,9 @@ class PCStatsManager:
         else:
             self.xp_thresholds = XPThreshholds(xp_thresholds)
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {
-            str(k): self.pc_stat_dict[k]._jot_json() for k in ctenums.CharID
+            str(k): self.pc_stat_dict[k].to_jot_json() for k in ctenums.CharID
         }
 
     @classmethod

--- a/sourcefiles/characters/pcrecruit.py
+++ b/sourcefiles/characters/pcrecruit.py
@@ -17,7 +17,7 @@ class RecruitSpot(typing.Protocol):
     held_char: ctenums.CharID
 
     # Still explicitly defining this in implementing classes
-    def _jot_json(self):
+    def to_jot_json(self):
         return str(self.held_char)
 
     def write_to_ctrom(self, ct_rom: ctrom.CTRom):
@@ -46,7 +46,7 @@ class CharRecruit(RecruitSpot):
         self.load_obj_id = load_obj_id
         self.recruit_obj_id = recruit_obj_id
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return str(self.held_char)
 
     # This might be poor naming, but the writing goes to the script manager
@@ -130,7 +130,7 @@ class StarterChar:
         self.held_char = held_char
         self.starter_num = starter_num
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return str(self.held_char)
 
     def write_to_ctrom(self, ct_rom: ctrom.CTRom):

--- a/sourcefiles/charassign.py
+++ b/sourcefiles/charassign.py
@@ -2,8 +2,6 @@ import ctenums
 import ctrom
 
 import eventcommand
-import eventfunction
-
 import randoconfig as cfg
 
 from eventcommand import EventCommand as EC, FuncSync as FS, Operation as OP

--- a/sourcefiles/charrando.py
+++ b/sourcefiles/charrando.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
 import copy
 import random
 
 from itertools import permutations
+from typing import List
 
 from techdb import TechDB
 from byteops import get_record, set_record, to_little_endian, \
@@ -69,7 +71,7 @@ def write_pcs_to_config(settings: rset.Settings, config: cfg.RandoConfig):
         if rset.GameFlags.DUPLICATE_CHARS in settings.gameflags:
             for pc_id in CharID:
                 avail_choices = settings.char_choices[int(pc_id)]
-                choices[pc_id] = random.choice(avail_choices)
+                choices[pc_id] = CharID(random.choice(avail_choices))
         # unique chars (default for char rando)
         else:
             all_choices = [p for p in permutations(range(0, 7), r=7)]
@@ -87,7 +89,7 @@ def write_pcs_to_config(settings: rset.Settings, config: cfg.RandoConfig):
                     'No valid permutation for unique characters based on '
                     'character choices.'
                 )
-            choices = {pc_id: permutation[pc_id] for pc_id in CharID}
+            choices = {pc_id: CharID(permutation[pc_id]) for pc_id in CharID}
 
         # Get Copies of stats
         orig_stats = {
@@ -112,7 +114,7 @@ def write_pcs_to_config(settings: rset.Settings, config: cfg.RandoConfig):
         # Turn choices back into a list for the rest of the stuff
         choices_list = [choices[CharID(i)] for i in range(7)]
     else:
-        choices_list = list(range(7))
+        choices_list = [CharID(x) for x in range(7)]
 
     dup_duals = rset.GameFlags.DUPLICATE_TECHS in settings.gameflags
     config.tech_db = get_reassign_techdb(config.tech_db,
@@ -1380,7 +1382,7 @@ def reassign_pc_magic(from_ind, to_ind, rom, db, magic_thresh):
     # applied when this option is selected
 
 
-def get_reassign_techdb(orig_db, reassign, dup_duals=False):
+def get_reassign_techdb(orig_db, reassign: List[CharID], dup_duals=False):
     # Make a db with the right menu/battle groups but no techs added yet
     new_db = max_expand_empty_db(orig_db, reassign, dup_duals)
 

--- a/sourcefiles/charrando.py
+++ b/sourcefiles/charrando.py
@@ -3,7 +3,6 @@ import random
 
 from itertools import permutations
 
-from characters import ctpcstats
 from techdb import TechDB
 from byteops import get_record, set_record, to_little_endian, \
     update_ptrs, to_rom_ptr

--- a/sourcefiles/charrando.py
+++ b/sourcefiles/charrando.py
@@ -3,7 +3,7 @@ import copy
 import random
 
 from itertools import permutations
-from typing import List
+from typing import Dict, List
 
 from techdb import TechDB
 from byteops import get_record, set_record, to_little_endian, \
@@ -67,10 +67,10 @@ def write_pcs_to_config(settings: rset.Settings, config: cfg.RandoConfig):
     # It was important to do the scaling first so that we know what level
     # and tech level to use when reassigning
     if rset.GameFlags.CHAR_RANDO in settings.gameflags:
-        choices = {}
+        choices: Dict[CharID, CharID] = {}
         if rset.GameFlags.DUPLICATE_CHARS in settings.gameflags:
             for pc_id in CharID:
-                avail_choices = settings.char_choices[int(pc_id)]
+                avail_choices = settings.char_settings.choices[int(pc_id)]
                 choices[pc_id] = CharID(random.choice(avail_choices))
         # unique chars (default for char rando)
         else:
@@ -80,7 +80,7 @@ def write_pcs_to_config(settings: rset.Settings, config: cfg.RandoConfig):
                 permutation = next(
                     p for p in shuffle
                     if all(
-                        p[pc_id] in settings.char_choices[pc_id]
+                        p[pc_id] in settings.char_settings.choices[pc_id]
                         for pc_id in CharID
                     )
                 )

--- a/sourcefiles/cli/adapters.py
+++ b/sourcefiles/cli/adapters.py
@@ -130,3 +130,23 @@ class GameFlagsAdapter(FlagsAdapter):
 
 class CosmeticFlagsAdapter(FlagsAdapter):
     _cls = rset.CosmeticFlags
+
+
+class CharSettingsAdapter(SettingsAdapter):
+    _cls = Type[rset.CharSettings]
+
+    @classmethod
+    def to_setting(cls, args: argparse.Namespace) -> rset.CharSettings:
+        '''Extract CharSettings from argparse.Namespace.'''
+        charset = rset.CharSettings()
+
+        for name in rset.CharNames.default():
+            name_arg = f"{name.lower()}_name"
+            if name_arg in args:
+                charset.names[name] = getattr(args, name_arg)
+
+            choices_arg = f"{name.lower()}_choices"
+            if choices_arg in args:
+                charset.choices[name] = getattr(args, choices_arg)
+
+        return charset

--- a/sourcefiles/cli/adapters.py
+++ b/sourcefiles/cli/adapters.py
@@ -13,6 +13,7 @@ from randosettings import Difficulty, ShopPrices, TechOrder
 from randosettings import GameMode as GM, GameFlags as GF
 
 SettingsFlags = Union[rset.GameFlags, rset.CosmeticFlags]
+GameArgumentType = Union[rset.GameMode, Difficulty, ShopPrices, TechOrder]
 
 
 class SettingsAdapter(Protocol):
@@ -42,12 +43,12 @@ class SettingsAdapter(Protocol):
 class ArgumentAdapter(SettingsAdapter):
     '''Adapter for converting single CLI arg directly into a setting.'''
 
-    _adapter: Mapping[str, rset.StrIntEnum] = {}
+    _adapter: Mapping[str, GameArgumentType] = {}
     _arg: str
-    _cls: Type[rset.StrIntEnum]
+    _cls: Type[GameArgumentType]
 
     @classmethod
-    def to_setting(cls, args: argparse.Namespace) -> rset.StrIntEnum:
+    def to_setting(cls, args: argparse.Namespace):
         '''Get coerced setting from args or default.'''
         if cls._arg in args:
             choice = getattr(args, cls._arg)
@@ -111,7 +112,7 @@ class FlagsAdapter(SettingsAdapter):
     _cls: Type[SettingsFlags]
 
     @classmethod
-    def to_setting(cls, args: argparse.Namespace, init: Optional[SettingsFlags] = None) -> SettingsFlags:
+    def to_setting(cls, args: argparse.Namespace, init: Optional[SettingsFlags] = None):
         if init is None:
             init = cls._cls(0)
         flags = (

--- a/sourcefiles/cli/adapters.py
+++ b/sourcefiles/cli/adapters.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+import argparse
+import functools
+import operator
+
+from typing import Any, Dict, Mapping, Optional, Protocol, Union, Type
+
+import randosettings as rset
+
+from cli.constants import FLAG_ENTRY_DICT, FlagEntry
+from randosettings import GameMode as GM
+
+SettingsFlags = Union[rset.GameFlags, rset.CosmeticFlags]
+
+
+class SettingsAdapter(Protocol):
+    '''Protocol to adapt CLI arguments to Settings object attributes.
+
+    These classes are used to provide a consistent interface for converting CLI argparse arguments
+    into attributes for a randosettings.Settings object (.to_setting classmethod). Some adapters
+    set a single value (e.g. GameModeAdapter) while others build and set complex nested objects
+    (e.g. MysterySettingsAdapter).
+    '''
+
+    # mapping of argument (per argparse.Namespace) mapped to values related to Settings attribute
+    _adapter: Mapping[str, Any] = {}
+    _cls: Type[Any]
+
+    @classmethod
+    def get(cls, arg: str) -> Any:
+        '''Get attribute values associated with specified argparse argument.'''
+        key = arg.lstrip('-').replace('-', '_')
+        return cls._adapter[key]
+
+    @classmethod
+    def to_setting(cls, args: argparse.Namespace):
+        raise NotImplementedError
+
+
+class ArgumentAdapter(SettingsAdapter):
+    '''Adapter for converting single CLI arg directly into a setting.'''
+
+    _adapter: Mapping[str, rset.StrIntEnum] = {}
+    _arg: str
+    _cls: Type[rset.StrIntEnum]
+
+    @classmethod
+    def to_setting(cls, args: argparse.Namespace) -> rset.StrIntEnum:
+        '''Get coerced setting from args or default.'''
+        if cls._arg in args:
+            choice = getattr(args, cls._arg)
+            return cls._adapter[choice.lower()]
+        return cls._cls.default()
+
+
+class GameModeAdapter(ArgumentAdapter):
+    _adapter: Dict[str, rset.GameMode] = {
+        'std': GM.STANDARD,
+        'lw': GM.LOST_WORLDS,
+        'loc': GM.LEGACY_OF_CYRUS,
+        'ia': GM.ICE_AGE,
+        'van': GM.VANILLA_RANDO,
+    }
+    _arg = 'mode'
+    _cls = rset.GameMode
+
+
+class DifficultyAdapter(ArgumentAdapter):
+    _adapter: Dict[str, rset.Difficulty] = {
+        'easy': rset.Difficulty.EASY,
+        'normal': rset.Difficulty.NORMAL,
+        'hard': rset.Difficulty.HARD,
+    }
+    _cls = rset.Difficulty
+
+
+class EnemyDifficultyAdapter(DifficultyAdapter):
+    _arg = 'enemy_difficulty'
+
+
+class ItemDifficultyAdapter(DifficultyAdapter):
+    _arg = 'item_difficulty'
+
+
+class TechOrderAdapter(ArgumentAdapter):
+    _adapter: Dict[str, rset.TechOrder] = {
+        'normal': rset.TechOrder.NORMAL,
+        'balanced': rset.TechOrder.BALANCED_RANDOM,
+        'random': rset.TechOrder.FULL_RANDOM,
+    }
+    _arg = 'tech_order'
+    _cls = rset.TechOrder
+
+
+class ShopPricesAdapter(ArgumentAdapter):
+    _adapter: Dict[str, rset.ShopPrices] = {
+        'normal': rset.ShopPrices.NORMAL,
+        'random': rset.ShopPrices.FULLY_RANDOM,
+        'mostrandom': rset.ShopPrices.MOSTLY_RANDOM,
+        'free': rset.ShopPrices.FREE,
+    }
+    _arg = 'shop_prices'
+    _cls = rset.ShopPrices
+
+
+class FlagsAdapter(SettingsAdapter):
+    '''Adapter for converting arguments into a Flag.'''
+
+    _cls: Type[SettingsFlags]
+
+    @classmethod
+    def to_setting(cls, args: argparse.Namespace, init: Optional[SettingsFlags] = None) -> SettingsFlags:
+        if init is None:
+            init = cls._cls(0)
+        flags = (
+            flag
+            for (flag, entry) in FLAG_ENTRY_DICT.items()
+            if isinstance(flag, cls._cls) and getattr(args, cls._flag_to_arg(entry), None) is True
+        )
+        return functools.reduce(operator.or_, flags, init)
+
+    @staticmethod
+    def _flag_to_arg(entry: FlagEntry) -> str:
+        return entry.name.lstrip('-').replace('-', '_')
+
+
+class GameFlagsAdapter(FlagsAdapter):
+    _cls = rset.GameFlags
+
+
+class CosmeticFlagsAdapter(FlagsAdapter):
+    _cls = rset.CosmeticFlags

--- a/sourcefiles/cli/adapters.py
+++ b/sourcefiles/cli/adapters.py
@@ -12,7 +12,7 @@ from cli.constants import FLAG_ENTRY_DICT, FlagEntry
 from randosettings import Difficulty, ShopPrices, TechOrder
 from randosettings import GameMode as GM, GameFlags as GF
 
-SettingsFlags = Union[rset.GameFlags, rset.CosmeticFlags]
+SettingsFlags = Union[rset.GameFlags, rset.CosmeticFlags, rset.ROFlags]
 GameArgumentType = Union[rset.GameMode, Difficulty, ShopPrices, TechOrder]
 
 
@@ -153,6 +153,23 @@ class CharSettingsAdapter(SettingsAdapter):
                 charset.choices[name] = getattr(args, choices_arg)
 
         return charset
+
+
+class BossRandoFlagsAdapter(FlagsAdapter):
+    _cls = rset.ROFlags
+
+
+class BossRandoSettingsAdapter(SettingsAdapter):
+    _cls = rset.ROSettings
+
+    @classmethod
+    def to_setting(cls, args: argparse.Namespace) -> rset.ROSettings:
+        '''Extract ROSettings from argparse.Namespace.'''
+        # just flags; spots, bosses are not implmeented options in CLI at this time
+        game_mode = GameModeAdapter.to_setting(args)
+        roset = rset.ROSettings.from_game_mode(game_mode)
+        roset.flags = BossRandoFlagsAdapter.to_setting(args)
+        return roset
 
 
 class BucketSettingsAdapter(SettingsAdapter):

--- a/sourcefiles/cli/adapters.py
+++ b/sourcefiles/cli/adapters.py
@@ -3,12 +3,14 @@ import argparse
 import functools
 import operator
 
-from typing import Any, Dict, Mapping, Optional, Protocol, Union, Type
+from typing import Any, Dict, Generator, List, Mapping, Optional, Protocol, Union, Tuple, Type
 
+import ctoptions
 import randosettings as rset
 
 from cli.constants import FLAG_ENTRY_DICT, FlagEntry
-from randosettings import GameMode as GM
+from randosettings import Difficulty, ShopPrices, TechOrder
+from randosettings import GameMode as GM, GameFlags as GF
 
 SettingsFlags = Union[rset.GameFlags, rset.CosmeticFlags]
 
@@ -66,12 +68,12 @@ class GameModeAdapter(ArgumentAdapter):
 
 
 class DifficultyAdapter(ArgumentAdapter):
-    _adapter: Dict[str, rset.Difficulty] = {
-        'easy': rset.Difficulty.EASY,
-        'normal': rset.Difficulty.NORMAL,
-        'hard': rset.Difficulty.HARD,
+    _adapter: Dict[str, Difficulty] = {
+        'easy': Difficulty.EASY,
+        'normal': Difficulty.NORMAL,
+        'hard': Difficulty.HARD,
     }
-    _cls = rset.Difficulty
+    _cls = Difficulty
 
 
 class EnemyDifficultyAdapter(DifficultyAdapter):
@@ -83,24 +85,24 @@ class ItemDifficultyAdapter(DifficultyAdapter):
 
 
 class TechOrderAdapter(ArgumentAdapter):
-    _adapter: Dict[str, rset.TechOrder] = {
-        'normal': rset.TechOrder.NORMAL,
-        'balanced': rset.TechOrder.BALANCED_RANDOM,
-        'random': rset.TechOrder.FULL_RANDOM,
+    _adapter: Dict[str, TechOrder] = {
+        'normal': TechOrder.NORMAL,
+        'balanced': TechOrder.BALANCED_RANDOM,
+        'random': TechOrder.FULL_RANDOM,
     }
     _arg = 'tech_order'
-    _cls = rset.TechOrder
+    _cls = TechOrder
 
 
 class ShopPricesAdapter(ArgumentAdapter):
-    _adapter: Dict[str, rset.ShopPrices] = {
-        'normal': rset.ShopPrices.NORMAL,
-        'random': rset.ShopPrices.FULLY_RANDOM,
-        'mostrandom': rset.ShopPrices.MOSTLY_RANDOM,
-        'free': rset.ShopPrices.FREE,
+    _adapter: Dict[str, ShopPrices] = {
+        'normal': ShopPrices.NORMAL,
+        'random': ShopPrices.FULLY_RANDOM,
+        'mostrandom': ShopPrices.MOSTLY_RANDOM,
+        'free': ShopPrices.FREE,
     }
     _arg = 'shop_prices'
-    _cls = rset.ShopPrices
+    _cls = ShopPrices
 
 
 class FlagsAdapter(SettingsAdapter):
@@ -150,3 +152,157 @@ class CharSettingsAdapter(SettingsAdapter):
                 charset.choices[name] = getattr(args, choices_arg)
 
         return charset
+
+
+class BucketSettingsAdapter(SettingsAdapter):
+    _adapter: Dict[str, str] = {
+        'bucket_disable_other_go': 'disable_other_go_modes',
+        'bucket_objectives_win': 'objectives_win',
+        'bucket_objective_count': 'num_objectives',
+        'bucket_objective_needed_count': 'num_objectives_needed',
+    }
+    _cls = rset.BucketSettings
+
+    @classmethod
+    def to_setting(cls, args: argparse.Namespace) -> rset.BucketSettings:
+        '''Extract BucketSettings from argparse.Namespace.'''
+        bset = rset.BucketSettings()
+        for arg, prop in cls._adapter.items():
+            if arg in args:
+                setattr(bset, prop, getattr(args, arg))
+
+        # objectives
+        objectives = (getattr(args, f"bucket_objective{obj}", None) for obj in range(1, bset.num_objectives + 1))
+        hints: List[str] = [hint for hint in objectives if hint is not None]
+        if hints:
+            bset.hints = hints
+
+        return bset
+
+
+class TabSettingsAdapter(SettingsAdapter):
+    _adapter: Dict[str, str] = {
+        'min_power_tab': 'power_min',
+        'max_power_tab': 'power_max',
+        'min_magic_tab': 'magic_min',
+        'max_magic_tab': 'magic_max',
+        'min_speed_tab': 'speed_min',
+        'max_speed_tab': 'speed_max',
+        'tab_scheme': 'scheme',
+        'tab_binom_success': 'binom_success',
+    }
+    _cls = rset.TabSettings
+
+    @classmethod
+    def to_setting(cls, args: argparse.Namespace):
+        '''Extract TabSettings from argparse.Namespace.'''
+        tset = rset.TabSettings()
+        for arg, prop in cls._adapter.items():
+            if arg in args:
+                setattr(tset, prop, getattr(args, arg))
+
+        if 'tab_scheme' in args:
+            scheme = getattr(args, 'tab_scheme')
+            if scheme == 'binomial':
+                setattr(tset, 'scheme', rset.TabRandoScheme.BINOMIAL)
+            elif scheme == 'uniform':
+                setattr(tset, 'scheme', rset.TabRandoScheme.UNIFORM)
+            else:
+                raise ValueError(f"Invalid tab scheme: {scheme}")
+
+        return tset
+
+
+class CTOptsAdapter(SettingsAdapter):
+    _adapter: Dict[str, str] = {
+        'save_menu_cursor': 'save_menu_cursor',
+        'save_battle_cursor': 'save_battle_cursor',
+        'save_skill_cursor_off': 'save_tech_cursor',
+        'skill_item_info_off': 'skill_item_info',
+        'consistent_paging': 'consistent_paging',
+        'battle_speed': 'battle_speed',
+        'battle_msg_speed': 'battle_msg_speed',
+        'battle_gauge_style': 'battle_gauge_style',
+        'background': 'menu_background',
+    }
+    _cls = ctoptions.CTOpts
+
+    @classmethod
+    def to_setting(cls, args: argparse.Namespace) -> ctoptions.CTOpts:
+        '''Extract CTOpts from argparse.Namespace.'''
+        ct_opts = ctoptions.CTOpts()
+        inverted_args = ['save_skill_cursor_off', 'skill_item_info_off']
+        plus_one_args = ['battle_speed', 'battle_msg_speed', 'background']
+
+        for arg, prop in cls._adapter.items():
+            if arg in args:
+                if arg in inverted_args:
+                    setattr(ct_opts, prop, not getattr(args, arg))
+                elif arg in plus_one_args:
+                    setattr(ct_opts, prop, getattr(args, arg) - 1)
+                else:
+                    setattr(ct_opts, prop, getattr(args, arg))
+        return ct_opts
+
+
+class MysterySettingsAdapter(SettingsAdapter):
+    _adapter: Dict[str, Tuple[str, Any]] = {
+        # game_mode_freqs
+        'mystery_mode_std': ('game_mode_freqs', GM.STANDARD),
+        'mystery_mode_lw': ('game_mode_freqs', GM.LOST_WORLDS),
+        'mystery_mode_loc': ('game_mode_freqs', GM.LEGACY_OF_CYRUS),
+        'mystery_mode_ia': ('game_mode_freqs', GM.ICE_AGE),
+        'mystery_mode_van': ('game_mode_freqs', GM.VANILLA_RANDO),
+        #  item_difficulty_freqs
+        'mystery_item_easy': ('item_difficulty_freqs', Difficulty.EASY),
+        'mystery_item_norm': ('item_difficulty_freqs', Difficulty.NORMAL),
+        'mystery_item_hard': ('item_difficulty_freqs', Difficulty.HARD),
+        # enemy_difficulty_freqs
+        'mystery_enemy_norm': ('enemy_difficulty_freqs', Difficulty.NORMAL),
+        'mystery_enemy_hard': ('enemy_difficulty_freqs', Difficulty.HARD),
+        # tech_order_freqs
+        'mystery_tech_norm': ('tech_order_freqs', TechOrder.NORMAL),
+        'mystery_tech_balanced': ('tech_order_freqs', TechOrder.BALANCED_RANDOM),
+        'mystery_tech_rand': ('tech_order_freqs', TechOrder.FULL_RANDOM),
+        # shop_price_freqs
+        'mystery_prices_norm': ('shop_price_freqs', ShopPrices.NORMAL),
+        'mystery_prices_mostly_rand': ('shop_price_freqs', ShopPrices.MOSTLY_RANDOM),
+        'mystery_prices_rand': ('shop_price_freqs', ShopPrices.FULLY_RANDOM),
+        'mystery_prices_free': ('shop_price_freqs', ShopPrices.FREE),
+        # flag_prob_dict
+        'mystery_flag_tab_treasures': ('flag_prob_dict', GF.TAB_TREASURES),
+        'mystery_flag_unlocked_magic': ('flag_prob_dict', GF.UNLOCKED_MAGIC),
+        'mystery_flag_bucket_list': ('flag_prob_dict', GF.BUCKET_LIST),
+        'mystery_flag_chronosanity': ('flag_prob_dict', GF.CHRONOSANITY),
+        'mystery_flag_boss_rando': ('flag_prob_dict', GF.BOSS_RANDO),
+        'mystery_flag_boss_scaling': ('flag_prob_dict', GF.BOSS_SCALE),
+        'mystery_flag_locked_chars': ('flag_prob_dict', GF.LOCKED_CHARS),
+        'mystery_flag_char_rando': ('flag_prob_dict', GF.CHAR_RANDO),
+        'mystery_flag_duplicate_chars': ('flag_prob_dict', GF.DUPLICATE_CHARS),
+        'mystery_flag_epoch_fail': ('flag_prob_dict', GF.EPOCH_FAIL),
+        'mystery_flag_gear_rando': ('flag_prob_dict', GF.GEAR_RANDO),
+        'mystery_flag_heal_rando': ('flag_prob_dict', GF.HEALING_ITEM_RANDO),
+    }
+    _cls = rset.MysterySettings
+
+    @classmethod
+    def args(cls, field: str) -> Generator[Tuple[str, Any], None, None]:
+        '''Get all CLI arguments and key in field in MysterySettings.'''
+        for arg, (item_field, key) in cls._adapter.items():
+            if item_field == field:
+                yield (arg, key)
+
+    @classmethod
+    def to_setting(cls, args: argparse.Namespace) -> rset.MysterySettings:
+        '''Get mystery settings from args.
+
+        This creates a MysterySettings object where all explicitly-passed values from the CLI
+        override the inherent defaults. Values not explicitly passed are suppressed by
+        the parser and will not override the defaults from randosettings.MysterySettings.
+        '''
+        mset = rset.MysterySettings()
+        for arg, (field, key) in cls._adapter.items():
+            if arg in args:
+                attr = getattr(mset, field)
+                attr[key] = getattr(args, arg)
+        return mset

--- a/sourcefiles/cli/adapters.py
+++ b/sourcefiles/cli/adapters.py
@@ -68,21 +68,23 @@ class GameModeAdapter(ArgumentAdapter):
     _cls = rset.GameMode
 
 
-class DifficultyAdapter(ArgumentAdapter):
+class EnemyDifficultyAdapter(ArgumentAdapter):
+    _adapter: Dict[str, Difficulty] = {
+        'normal': Difficulty.NORMAL,
+        'hard': Difficulty.HARD,
+    }
+    _arg = 'enemy_difficulty'
+    _cls = Difficulty
+
+
+class ItemDifficultyAdapter(ArgumentAdapter):
     _adapter: Dict[str, Difficulty] = {
         'easy': Difficulty.EASY,
         'normal': Difficulty.NORMAL,
         'hard': Difficulty.HARD,
     }
-    _cls = Difficulty
-
-
-class EnemyDifficultyAdapter(DifficultyAdapter):
-    _arg = 'enemy_difficulty'
-
-
-class ItemDifficultyAdapter(DifficultyAdapter):
     _arg = 'item_difficulty'
+    _cls = Difficulty
 
 
 class TechOrderAdapter(ArgumentAdapter):

--- a/sourcefiles/cli/arguments.py
+++ b/sourcefiles/cli/arguments.py
@@ -18,7 +18,6 @@ from randosettings import GameFlags as GF, CosmeticFlags as CF
 # https://stackoverflow.com/questions/3853722/
 # how-to-insert-newlines-on-argparse-help-text
 class SmartFormatter(argparse.HelpFormatter):
-
     def _split_lines(self, text, width):
         if text.startswith('R|'):
             return text[2:].splitlines()
@@ -34,8 +33,8 @@ def args_to_settings(args: argparse.Namespace) -> rset.Settings:
     ret_set.game_mode = adp.GameModeAdapter.to_setting(args)
     ret_set.gameflags = adp.GameFlagsAdapter.to_setting(args)
     ret_set.initial_flags = copy.deepcopy(ret_set.gameflags)
-    ret_set.item_difficulty =  adp.ItemDifficultyAdapter.to_setting(args)
-    ret_set.enemy_difficulty =  adp.EnemyDifficultyAdapter.to_setting(args)
+    ret_set.item_difficulty = adp.ItemDifficultyAdapter.to_setting(args)
+    ret_set.enemy_difficulty = adp.EnemyDifficultyAdapter.to_setting(args)
     ret_set.techorder = adp.TechOrderAdapter.to_setting(args)
     ret_set.shopprices = adp.ShopPricesAdapter.to_setting(args)
     ret_set.mystery_settings = adp.MysterySettingsAdapter.to_setting(args)
@@ -56,6 +55,7 @@ class Argument:
     assigned when randosettings.Settings is initialized. This prevents needing to
     double set default values in this file and elsewhere and prevents such regressions.
     '''
+
     name: Tuple[str, ...]
     options: Dict[str, Any]
 
@@ -106,9 +106,20 @@ class FlagsArgumentGroup(ArgumentGroup):
 class BasicFlagsAG(FlagsArgumentGroup):
     _title = 'Basic Flags'
     _flags = [
-        GF.FIX_GLITCH, GF.BOSS_SCALE, GF.ZEAL_END, GF.FAST_PENDANT, GF.LOCKED_CHARS, GF.UNLOCKED_MAGIC,
-        GF.CHRONOSANITY, GF.TAB_TREASURES, GF.BOSS_RANDO, GF.CHAR_RANDO, GF.MYSTERY, GF.HEALING_ITEM_RANDO,
-        GF.GEAR_RANDO, GF.EPOCH_FAIL
+        GF.FIX_GLITCH,
+        GF.BOSS_SCALE,
+        GF.ZEAL_END,
+        GF.FAST_PENDANT,
+        GF.LOCKED_CHARS,
+        GF.UNLOCKED_MAGIC,
+        GF.CHRONOSANITY,
+        GF.TAB_TREASURES,
+        GF.BOSS_RANDO,
+        GF.CHAR_RANDO,
+        GF.MYSTERY,
+        GF.HEALING_ITEM_RANDO,
+        GF.GEAR_RANDO,
+        GF.EPOCH_FAIL,
     ]
 
 
@@ -130,8 +141,12 @@ class LogicKIFlagsAG(FlagsArgumentGroup):
 class LogicSpotFlagsAG(FlagsArgumentGroup):
     _title = 'Logic Tweak Flags that add/remove a KI Spot'
     _flags = [
-        GF.ADD_BEKKLER_SPOT, GF.ADD_OZZIE_SPOT, GF.ADD_RACELOG_SPOT, GF.ADD_CYRUS_SPOT, GF.VANILLA_ROBO_RIBBON,
-        GF.REMOVE_BLACK_OMEN_SPOT
+        GF.ADD_BEKKLER_SPOT,
+        GF.ADD_OZZIE_SPOT,
+        GF.ADD_RACELOG_SPOT,
+        GF.ADD_CYRUS_SPOT,
+        GF.VANILLA_ROBO_RIBBON,
+        GF.REMOVE_BLACK_OMEN_SPOT,
     ]
 
 
@@ -222,7 +237,8 @@ class CharRandoAG(ArgumentGroup):
     @classmethod
     def arguments(cls) -> Generator[Argument, None, None]:
         yield Argument(
-            '--duplicate-characters', '-dc',
+            '--duplicate-characters',
+            '-dc',
             help='Allow multiple copies of a character to be present in a seed.',
             action='store_true',
         )
@@ -301,13 +317,15 @@ class GeneralOptionsAG(ArgumentGroup):
             type=str.lower,
         )
         yield Argument(
-            '--item-difficulty', '-idiff',
+            '--item-difficulty',
+            '-idiff',
             help=f"controls quality of treasure, drops, and starting gold [{diff_default}]",
             choices=['easy', 'normal', 'hard'],
             type=str.lower,
         )
         yield Argument(
-            '--enemy-difficulty', '-ediff',
+            '--enemy-difficulty',
+            '-ediff',
             help=f"controls strength of enemies and xp/tp rewards [{diff_default}]",
             choices=['normal', 'hard'],
             type=str.lower,
@@ -467,18 +485,21 @@ class TabSettingsAG(ArgumentGroup):
 
 class RandomizerCLIOptionsAG(ArgumentGroup):
     '''Options specific to randomizer.py.'''
+
     _title = 'Generation options'
 
     @classmethod
     def arguments(cls) -> Generator[Argument, None, None]:
         yield Argument(
-            '--input-file', '-i',
+            '--input-file',
+            '-i',
             required=True,
             help='path to Chrono Trigger (U) rom',
             type=Path,
         )
         yield Argument(
-            '--output-path', '-o',
+            '--output-path',
+            '-o',
             help='path to output directory (default same as input)',
             type=Path,
         )
@@ -528,6 +549,7 @@ ALL_POST_GENERATION_AG: List[Type[ArgumentGroup]] = [
     CharNamesAG,
     GameOptionsAG,
 ]
+
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(formatter_class=SmartFormatter)

--- a/sourcefiles/cli/arguments.py
+++ b/sourcefiles/cli/arguments.py
@@ -500,6 +500,7 @@ class RandomizerCLIOptionsAG(ArgumentGroup):
             '--output-path',
             '-o',
             help='path to output directory (default same as input)',
+            default=None,
             type=Path,
         )
         yield Argument(
@@ -509,11 +510,13 @@ class RandomizerCLIOptionsAG(ArgumentGroup):
         yield Argument(
             '--spoilers',
             help='generate spoilers with the randomized rom.',
+            default=None,
             action='store_true',
         )
         yield Argument(
             '--json-spoilers',
             help='generate json spoilers with the randomized rom.',
+            default=None,
             action='store_true',
         )
 

--- a/sourcefiles/cli/arguments.py
+++ b/sourcefiles/cli/arguments.py
@@ -254,10 +254,9 @@ class CharRandoAG(ArgumentGroup):
             'either Lucca or Robo.  If the list is preceded with "not" '
             '(e.g. not lucca ayla) then all except the listed characters will be '
             'allowed.',
-            default='all',
         )
         for name in rset.CharNames.default()[1:-1]:
-            yield Argument(f"--{name.lower()}-choices", help='Same as --crono-choices.', default='all')
+            yield Argument(f"--{name.lower()}-choices", help='Same as --crono-choices.')
 
 
 class GameOptionsAG(ArgumentGroup):

--- a/sourcefiles/cli/arguments.py
+++ b/sourcefiles/cli/arguments.py
@@ -12,7 +12,7 @@ import objectivehints as obhint
 import randosettings as rset
 from cli.constants import FLAG_ENTRY_DICT
 from randosettings import Difficulty
-from randosettings import GameFlags as GF, CosmeticFlags as CF
+from randosettings import GameFlags as GF, CosmeticFlags as CF, ROFlags as RO
 
 
 # https://stackoverflow.com/questions/3853722/
@@ -42,6 +42,7 @@ def args_to_settings(args: argparse.Namespace) -> rset.Settings:
     ret_set.ctoptions = adp.CTOptsAdapter.to_setting(args)
     ret_set.char_settings = adp.CharSettingsAdapter.to_setting(args)
     ret_set.tab_settings = adp.TabSettingsAdapter.to_setting(args)
+    ret_set.ro_settings = adp.BossRandoSettingsAdapter.to_setting(args)
     ret_set.bucket_settings = adp.BucketSettingsAdapter.to_setting(args)
     return ret_set
 
@@ -123,6 +124,12 @@ class BasicFlagsAG(FlagsArgumentGroup):
     ]
 
 
+class BossRandoFlagsAG(FlagsArgumentGroup):
+    _title = 'Boss Rando Flags'
+    _desc = 'These options are only valid when --boss-randomization [-ro] is set'
+    _flags = [RO.BOSS_SPOT_HP, RO.PRESERVE_PARTS]
+
+
 class QoLFlagsAG(FlagsArgumentGroup):
     _title = 'QoL Flags'
     _flags = [GF.FAST_TABS, GF.VISIBLE_HEALTH, GF.BOSS_SIGHTSCOPE, GF.FREE_MENU_GLITCH]
@@ -196,19 +203,6 @@ class BucketListAG(ArgumentGroup):
         if not valid:
             raise argparse.ArgumentTypeError(f"Invalid bucket objective: '{msg}'")
         return hint
-
-
-class BossRandoAG(ArgumentGroup):
-    _title = '-ro Options'
-    _desc = 'These options are only valid when --boss-randomization [-ro] is set'
-
-    @classmethod
-    def arguments(cls) -> Generator[Argument, None, None]:
-        yield Argument(
-            '--boss-spot-hp',
-            help='boss HP is set to match the vanilla boss HP in each spot',
-            action='store_true',
-        )
 
 
 class CharNamesAG(ArgumentGroup):
@@ -526,7 +520,7 @@ class RandomizerCLIOptionsAG(ArgumentGroup):
 ALL_GENERATION_AG: List[Type[ArgumentGroup]] = [
     GeneralOptionsAG,
     BasicFlagsAG,
-    BossRandoAG,
+    BossRandoFlagsAG,
     CharRandoAG,
     TabSettingsAG,
     QoLFlagsAG,

--- a/sourcefiles/cli/constants.py
+++ b/sourcefiles/cli/constants.py
@@ -175,16 +175,16 @@ FLAG_ENTRY_DICT: Dict[SettingsFlags, FlagEntry] = {
 
 # flag, name, default
 MYSTERY_FLAG_PROB_ENTRIES: List[Tuple['rset.GameFlags', str, float]] = [
-    (GF.TAB_TREASURES, "flag_tab_treasures", 0.10),
-    (GF.UNLOCKED_MAGIC, "flag_unlocked_magic", 0.50),
-    (GF.BUCKET_LIST, "flag_bucket_list", 0.15),
-    (GF.CHRONOSANITY, "flag_chronosanity", 0.30),
-    (GF.BOSS_RANDO, "flag_boss_rando", 0.50),
-    (GF.BOSS_SCALE, "flag_boss_scaling", 0.30),
-    (GF.LOCKED_CHARS, "flag_locked_chars", 0.25),
-    (GF.CHAR_RANDO, "flag_char_rando", 0.5),
-    (GF.DUPLICATE_CHARS, "flag_duplicate_chars", 0.25),
-    (GF.EPOCH_FAIL, "flag_epoch_fail", 0.50),
-    (GF.GEAR_RANDO, "flag_gear_rando", 0.25),
-    (GF.HEALING_ITEM_RANDO, "flag_heal_rando", 0.25),
+    (GF.TAB_TREASURES, "flag-tab-treasures", 0.10),
+    (GF.UNLOCKED_MAGIC, "flag-unlocked-magic", 0.50),
+    (GF.BUCKET_LIST, "flag-bucket-list", 0.15),
+    (GF.CHRONOSANITY, "flag-chronosanity", 0.30),
+    (GF.BOSS_RANDO, "flag-boss-rando", 0.50),
+    (GF.BOSS_SCALE, "flag-boss-scaling", 0.30),
+    (GF.LOCKED_CHARS, "flag-locked-chars", 0.25),
+    (GF.CHAR_RANDO, "flag-char-rando", 0.5),
+    (GF.DUPLICATE_CHARS, "flag-duplicate-chars", 0.25),
+    (GF.EPOCH_FAIL, "flag-epoch-fail", 0.50),
+    (GF.GEAR_RANDO, "flag-gear-rando", 0.25),
+    (GF.HEALING_ITEM_RANDO, "flag-heal-rando", 0.25),
 ]

--- a/sourcefiles/cli/constants.py
+++ b/sourcefiles/cli/constants.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Union, Tuple
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from randosettings import GameFlags as GF, CosmeticFlags as CF
 
@@ -172,19 +172,3 @@ FLAG_ENTRY_DICT: Dict[SettingsFlags, FlagEntry] = {
         "disable most flashing effects"
     )
 }
-
-# flag, name, default
-MYSTERY_FLAG_PROB_ENTRIES: List[Tuple['rset.GameFlags', str, float]] = [
-    (GF.TAB_TREASURES, "flag-tab-treasures", 0.10),
-    (GF.UNLOCKED_MAGIC, "flag-unlocked-magic", 0.50),
-    (GF.BUCKET_LIST, "flag-bucket-list", 0.15),
-    (GF.CHRONOSANITY, "flag-chronosanity", 0.30),
-    (GF.BOSS_RANDO, "flag-boss-rando", 0.50),
-    (GF.BOSS_SCALE, "flag-boss-scaling", 0.30),
-    (GF.LOCKED_CHARS, "flag-locked-chars", 0.25),
-    (GF.CHAR_RANDO, "flag-char-rando", 0.5),
-    (GF.DUPLICATE_CHARS, "flag-duplicate-chars", 0.25),
-    (GF.EPOCH_FAIL, "flag-epoch-fail", 0.50),
-    (GF.GEAR_RANDO, "flag-gear-rando", 0.25),
-    (GF.HEALING_ITEM_RANDO, "flag-heal-rando", 0.25),
-]

--- a/sourcefiles/cli/constants.py
+++ b/sourcefiles/cli/constants.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, List, Optional, Union, Tuple
+
+from randosettings import GameFlags as GF, CosmeticFlags as CF
+
+if TYPE_CHECKING:
+    import randosettings as rset
+
+SettingsFlags = Union['rset.GameFlags', 'rset.CosmeticFlags']
+
+
+@dataclass
+class FlagEntry:
+    name: str = ""
+    short_name: Optional[str] = None
+    help_text: Optional[str] = None
+
+
+FLAG_ENTRY_DICT: Dict[SettingsFlags, FlagEntry] = {
+    GF.FIX_GLITCH: FlagEntry(
+        "--fix-glitch", "-g",
+        "disable save anywhere and HP overflow glitches"),
+    GF.BOSS_SCALE: FlagEntry(
+        "--boss-scale", "-b",
+        "scale bosses based on key-item locations"),
+    GF.ZEAL_END: FlagEntry(
+        "--zeal-end", "-z",
+        "allow the game to be won when Zeal is defeated in the "
+        "Black Omen"),
+    GF.FAST_PENDANT: FlagEntry(
+        "--fast-pendant", "-p",
+        "the pendant will be charged when 2300 is reached"),
+    GF.LOCKED_CHARS: FlagEntry(
+        "--locked-chars", "-c",
+        "require dreamstone for the dactyl character and factory for "
+        "the Proto Dome character"),
+    GF.UNLOCKED_MAGIC: FlagEntry(
+        "--unlocked-magic", "-m",
+        "magic is unlocked from the beginning of the game without "
+        "visiting Spekkio"),
+    GF.CHRONOSANITY: FlagEntry(
+        "--chronosanity", "-cr",
+        "key items may be found in treasure chests"),
+    GF.ROCKSANITY: FlagEntry(
+        "--rocksanity", None,
+        "rocks are added as key items and key items may be found "
+        "in rock locations"),
+    GF.TAB_TREASURES: FlagEntry(
+        "--tab-treasures", None,
+        "all treasure chests contain tabs"),
+    GF.BOSS_RANDO: FlagEntry(
+        "--boss-randomization", "-ro",
+        "randomize the location of bosses and scale based on location"),
+    GF.CHAR_RANDO: FlagEntry(
+        "--char-rando", "-rc",
+        "randomize character identities and models"), 
+    GF.DUPLICATE_CHARS: FlagEntry(
+        "--duplicate-characters", "-dc",
+        "allow multiple copies of a character to be present in a seed"),
+    GF.DUPLICATE_TECHS: FlagEntry(
+        "--duplicate-techs", None,
+        "allow duplicate characters to perform dual techs together"),
+    GF.VISIBLE_HEALTH: FlagEntry(
+        "--visible-health", None,
+        "the sightscope effect will always be present"),
+    GF.FAST_TABS: FlagEntry(
+        "--fast-tabs", None,
+        "picking up a tab will not pause movement for the fanfare"),
+    GF.BUCKET_LIST: FlagEntry(
+        "--bucket-list", "-k",
+        "allow the End of Time bucket to Lavos to activate when enough "
+        "objectives have been completed."),
+    GF.TECH_DAMAGE_RANDO: FlagEntry(
+        "--tech-damage-rando", None,
+        "Randomize the damage dealt by single techs."),
+    GF.MYSTERY: FlagEntry(
+        "--mystery", None,
+        "choose flags randomly according to mystery settings"),
+    GF.BOSS_SIGHTSCOPE: FlagEntry(
+        "--boss-sightscope", None,
+        "allow the sightscope to work on bosses"),
+    GF.USE_ANTILIFE: FlagEntry(
+        "--use-antilife", None,
+        "use Anti-Life instead of Black Hole for Magus"),
+    GF.TACKLE_EFFECTS_ON: FlagEntry(
+        "--tackle-on-hit-effects", None,
+        "allow Robo Tackle to use the on-hit effects of Robo's weapons"),
+    GF.HEALING_ITEM_RANDO: FlagEntry(
+        "--healing-item-rando", "-he",
+        "randomizes effects of healing items"),
+    GF.FREE_MENU_GLITCH: FlagEntry(
+        "--free-menu-glitch", None,
+        "provides a longer window to enter the menu prior to Lavos3 and "
+        "Zeal2"),
+    GF.GEAR_RANDO: FlagEntry(
+        "--gear-rando", "-q",
+        "randomizes effects on weapons, armors, and accessories"),
+    GF.STARTERS_SUFFICIENT: FlagEntry(
+        "--starters-sufficient", None,
+        "go mode will be acheivable without recruiting additional "
+        "characters"),
+    GF.EPOCH_FAIL: FlagEntry(
+        "--epoch-fail", "-ef",
+        "Epoch flight must be unlocked by bringing the JetsOfTime to "
+        "Dalton in the Snail Stop"),
+    GF.BOSS_SPOT_HP: FlagEntry(
+        "--boss-spot-hp",
+        "boss HP is set to match the vanilla boss HP in each spot"),
+    # Logic Tweak flags from VanillaRando mode
+    GF.UNLOCKED_SKYGATES: FlagEntry(
+        "--unlocked-skyways", None,
+        "Skyways are available as soon as 12kBC is. Normal go mode is still "
+        "needed to unlock the Ocean Palace."),
+    GF.ADD_SUNKEEP_SPOT: FlagEntry(
+        "--add-sunkeep-spot", None,
+        "Adds Sun Stone as an independent key item.  Moonstone charges to a "
+        "random item"),
+    GF.ADD_BEKKLER_SPOT: FlagEntry(
+        "--add-bekkler-spot", None,
+        "C.Trigger unlocks clone game for a KI"),
+    GF.ADD_CYRUS_SPOT: FlagEntry(
+        "--add-cyrus-spot", None,
+        "Gain a KI from Cyrus's Grave w/ Frog.  No Frog stat boost."),
+    GF.RESTORE_TOOLS: FlagEntry(
+        "--restore-tools", None,
+        "Adds Tools. Tools will fix Norther Ruins."),
+    GF.ADD_OZZIE_SPOT: FlagEntry(
+        "--add-ozzie-spot", None, "Gain a KI after Ozzie's Fort."),
+    GF.RESTORE_JOHNNY_RACE: FlagEntry(
+        "--restore-johnny-race", None,
+        "Add bike key and Johnny Race. Bike Key is required to cross Lab32."),
+    GF.ADD_RACELOG_SPOT: FlagEntry(
+        "--add-racelog-spot", None,
+        "Gain a KI from the vanilla Race Log chest."),
+    GF.REMOVE_BLACK_OMEN_SPOT: FlagEntry(
+        "--remove-black-omen-spot", None,
+        "Removes Black Omen rock chest being a possible KI."),
+    GF.SPLIT_ARRIS_DOME: FlagEntry(
+        "--split-arris-dome", None,
+        "Get one key item from the dead guy after Guardian.  Get a second "
+        "after checking the Arris dome computer and bringing the Seed "
+        "(new KI) to Doan."),
+    GF.VANILLA_ROBO_RIBBON: FlagEntry(
+        "--vanilla-robo-ribbon", None,
+        "Gain Robo stat boost from defeating AtroposXR.  If no Atropos in "
+        "seed, then gain from Geno Dome."),
+    GF.VANILLA_DESERT: FlagEntry(
+        "--vanilla-desert", None,
+        "The sunken desert only unlocks after talking to the plant lady "
+        "in Zeal"),
+    # Cosmetic Flags
+    CF.AUTORUN: FlagEntry(
+        "--autorun", None,
+        "Automatically run.  Push run button to walk."
+    ),
+    CF.DEATH_PEAK_ALT_MUSIC: FlagEntry(
+        "--death-peak-alt-music", None,
+        "use Singing Mountain track on Death Peak"
+    ),
+    CF.ZENAN_ALT_MUSIC: FlagEntry(
+        "--zenan-alt-music", None,
+        "use alt battle theme for Zenan Bridge"
+    ),
+    CF.QUIET_MODE: FlagEntry(
+        "--quiet", None,
+        "disable all music (not sound effects)"
+    ),
+    CF.REDUCE_FLASH: FlagEntry(
+        "--reduce-flashes", None,
+        "disable most flashing effects"
+    )
+}
+
+# flag, name, default
+MYSTERY_FLAG_PROB_ENTRIES: List[Tuple['rset.GameFlags', str, float]] = [
+    (GF.TAB_TREASURES, "flag_tab_treasures", 0.10),
+    (GF.UNLOCKED_MAGIC, "flag_unlocked_magic", 0.50),
+    (GF.BUCKET_LIST, "flag_bucket_list", 0.15),
+    (GF.CHRONOSANITY, "flag_chronosanity", 0.30),
+    (GF.BOSS_RANDO, "flag_boss_rando", 0.50),
+    (GF.BOSS_SCALE, "flag_boss_scaling", 0.30),
+    (GF.LOCKED_CHARS, "flag_locked_chars", 0.25),
+    (GF.CHAR_RANDO, "flag_char_rando", 0.5),
+    (GF.DUPLICATE_CHARS, "flag_duplicate_chars", 0.25),
+    (GF.EPOCH_FAIL, "flag_epoch_fail", 0.50),
+    (GF.GEAR_RANDO, "flag_gear_rando", 0.25),
+    (GF.HEALING_ITEM_RANDO, "flag_heal_rando", 0.25),
+]

--- a/sourcefiles/cli/constants.py
+++ b/sourcefiles/cli/constants.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
-from randosettings import GameFlags as GF, CosmeticFlags as CF
+from randosettings import GameFlags as GF, CosmeticFlags as CF, ROFlags as RO
 
 if TYPE_CHECKING:
     import randosettings as rset
 
-SettingsFlags = Union['rset.GameFlags', 'rset.CosmeticFlags']
+SettingsFlags = Union['rset.GameFlags', 'rset.CosmeticFlags', 'rset.ROFlags']
 
 
 @dataclass
@@ -105,9 +105,13 @@ FLAG_ENTRY_DICT: Dict[SettingsFlags, FlagEntry] = {
         "--epoch-fail", "-ef",
         "Epoch flight must be unlocked by bringing the JetsOfTime to "
         "Dalton in the Snail Stop"),
-    GF.BOSS_SPOT_HP: FlagEntry(
-        "--boss-spot-hp",
+    # Boss Rando flags
+    RO.BOSS_SPOT_HP: FlagEntry(
+        "--boss-spot-hp", None,
         "boss HP is set to match the vanilla boss HP in each spot"),
+    RO.PRESERVE_PARTS: FlagEntry(
+        "--legacy-boss-placement", None,
+        "use legacy boss placement for boss rando"),
     # Logic Tweak flags from VanillaRando mode
     GF.UNLOCKED_SKYGATES: FlagEntry(
         "--unlocked-skyways", None,

--- a/sourcefiles/cosmetichacks.py
+++ b/sourcefiles/cosmetichacks.py
@@ -27,9 +27,7 @@ def set_pc_names(
     '''
     Provide names to be used for characters and epoch.
     '''
-    default_names = (
-        'Crono', 'Marle', 'Lucca', 'Robo', 'Frog', 'Ayla', 'Magus', 'Epoch'
-    )
+    default_names = rset.CharNames.default()
 
     copy_str = bytearray()
 

--- a/sourcefiles/ctevent.py
+++ b/sourcefiles/ctevent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import enum
-from typing import ByteString, Optional, Tuple
+from pathlib import Path
+from typing import ByteString, Optional, Union, Tuple
 
 from ctdecompress import compress, decompress, get_compressed_length, \
     get_compressed_packet
@@ -102,6 +103,8 @@ def get_location_script(rom, loc_id):
 # of relevant entities (objects, functions).
 class Event:
 
+    _flux_path: Path = Path(__file__).parent / 'flux'
+
     def __init__(self):
         self.num_objects = 0
 
@@ -126,8 +129,7 @@ class Event:
     @staticmethod
     def from_flux(filename: str):
         '''Reads a .flux file and loads it into an Event'''
-
-        with open(filename, 'rb') as infile:
+        with Event._get_flux_path(filename).open('rb') as infile:
             flux = bytearray(infile.read())
 
         # These first bytes are used internally by TF, but they don't seem
@@ -1259,6 +1261,19 @@ class Event:
         self.__shift_starts(ins_position, len(new_commands))
 
         self.data[ins_position:ins_position] = new_commands
+
+
+    @staticmethod
+    def _get_flux_path(filename: Union[Path, str]) -> Path:
+        '''Coerce filename path to use flux from "flux" directory in package instead of relative to CWD.
+
+        If filename starts with './flux/', it is replaced with the location of "flux" directory.
+        '''
+        parts = Path(filename).parts
+        if parts[0] == 'flux':
+            # strip off leading './flux/' if included in filename
+            parts = parts[1:]
+        return Path(Event._flux_path, *parts)
 
 
 # Find the length of a location's event script

--- a/sourcefiles/ctoptions.py
+++ b/sourcefiles/ctoptions.py
@@ -1,12 +1,15 @@
 '''
 Module for preconfiguring in-game options at compile time
 '''
-from typing import Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 import byteops
 from ctenums import ActionMap, InputMap
 from ctrom import CTRom
 from ctevent import FSWriteType
+
+if TYPE_CHECKING:
+    import randosettings as rset
 
 class ControllerBinds:
     '''
@@ -499,6 +502,9 @@ class CTOpts:
         
         rom.seek(0x011483 + 1) # AND #$10
         rom.write(0x20.to_bytes(1, 'little'))
+
+    def to_jot_json(self) -> Dict[str, 'rset.JSONPrimitive']:
+        return {k: v for k, v in self}
         
 
 if __name__ == '__main__':

--- a/sourcefiles/ctoptions.py
+++ b/sourcefiles/ctoptions.py
@@ -444,6 +444,9 @@ class CTOpts:
         
         return ret
 
+    def __eq__(self, other) -> bool:
+        return all(getattr(other, key, None) == value for key, value in self)
+
     def __iter__(self):
         
         ret = {
@@ -460,7 +463,6 @@ class CTOpts:
             'battle_gauge_style': self.battle_gauge_style,
             'consistent_paging': self.consistent_paging
         }
-        
 
         return iter(ret.items())
 

--- a/sourcefiles/ctoptions.py
+++ b/sourcefiles/ctoptions.py
@@ -95,7 +95,7 @@ class ControllerBinds:
 
         try:
             check = {x: binds[x] for x in ActionMap}
-        except:
+        except KeyError:
             return False
 
         assigned = [y for x, y in check.items()]

--- a/sourcefiles/ctstrings.py
+++ b/sourcefiles/ctstrings.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import pickle
 import typing
 
+from pathlib import Path
+
 import byteops
 
 
@@ -118,6 +120,8 @@ class CTHuffmanTree:
 # methods for converting to python string and compression.
 class CTString(bytearray):
 
+    _pickles_path: Path = Path(__file__).parent / 'pickles'
+
     # This list might not be exactly right.  I need to encounter each keyword
     # in a flux file before I know exactly what name flux uses.
 
@@ -145,7 +149,7 @@ class CTString(bytearray):
         '{:inf:}', 'none'
     ]
 
-    huffman_table = pickle.load(open('./pickles/huffman_table.pickle', 'rb'))
+    huffman_table = pickle.load(Path(_pickles_path / 'huffman_table.pickle').open('rb'))
     huffman_tree = CTHuffmanTree(huffman_table)
 
     # There's nothing special that we do for CTStrings.

--- a/sourcefiles/enemystats.py
+++ b/sourcefiles/enemystats.py
@@ -121,7 +121,7 @@ class EnemyStats:
         self._set_name(ctstrings.CTString(name_bytes))
         self._set_rewards(reward_bytes)
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {
             'hp': self.hp,
             'level': self.level,

--- a/sourcefiles/itemdata.py
+++ b/sourcefiles/itemdata.py
@@ -1083,7 +1083,7 @@ class Item:
         self.name = bytearray(name_bytes)
         self.desc = bytearray(desc_bytes)
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {
             'name': self.get_name_as_str(True),
             'desc': self.get_desc_as_str(),
@@ -1554,5 +1554,5 @@ class ItemDB:
 
         # fs.print_blocks()
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {str(x): self.item_dict[x] for x in self.item_dict}

--- a/sourcefiles/jotjson.py
+++ b/sourcefiles/jotjson.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
 import json
-import randosettings as rset
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import randosettings as rset
+
 
 class JOTJSONEncoder(json.JSONEncoder):
-    def default(self, obj):
+    def default(self, obj) -> 'rset.JSONType':
         if hasattr(obj, '_jot_json'):
             return obj._jot_json()
         elif isinstance(obj, rset.GameFlags):

--- a/sourcefiles/jotjson.py
+++ b/sourcefiles/jotjson.py
@@ -1,5 +1,4 @@
 import json
-import randoconfig as cfg
 import randosettings as rset
 
 class JOTJSONEncoder(json.JSONEncoder):

--- a/sourcefiles/jotjson.py
+++ b/sourcefiles/jotjson.py
@@ -9,10 +9,6 @@ if TYPE_CHECKING:
 
 class JOTJSONEncoder(json.JSONEncoder):
     def default(self, obj) -> 'rset.JSONType':
-        if hasattr(obj, '_jot_json'):
-            return obj._jot_json()
-        elif isinstance(obj, rset.GameFlags):
-            return [str(flag) for flag in rset.GameFlags if flag in obj]
-        elif isinstance(obj, rset.CosmeticFlags):
-            return [str(flag) for flag in rset.CosmeticFlags if flag in obj]
+        if hasattr(obj, 'to_jot_json'):
+            return obj.to_jot_json()
         return json.JSONEncoder.default(self, obj)

--- a/sourcefiles/logicfactory.py
+++ b/sourcefiles/logicfactory.py
@@ -1,4 +1,3 @@
-import random
 import typing
 from typing import List, Optional, Type
 from math import ceil

--- a/sourcefiles/logictypes.py
+++ b/sourcefiles/logictypes.py
@@ -370,7 +370,7 @@ class Location:
     def __repr__(self):
         return f'<Location.{self.getName()}>'
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {self.getName(): str(self.getKeyItem())}
 
     #
@@ -504,7 +504,7 @@ class LinkedLocation():
         self.location1 = location1
         self.location2 = location2
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return {self.getName(): str(self.getKeyItem())}
 
     def getName(self):

--- a/sourcefiles/logicwriter_chronosanity.py
+++ b/sourcefiles/logicwriter_chronosanity.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 import random as rand
 
+from typing import List
+
 
 # jets of time libraries
 import logicfactory
@@ -20,7 +22,7 @@ import randosettings as rset
 #
 
 # Script variables
-locationGroups = []
+locationGroups: List[logictypes.LocationGroup] = []
 
 
 #
@@ -30,7 +32,7 @@ locationGroups = []
 #
 # return: List of all available LocationGroups
 #
-def getAvailableLocations(game: logictypes.Game) -> list[logictypes.Location]:
+def getAvailableLocations(game: logictypes.Game) -> List[logictypes.LocationGroup]:
   # Have the game object update what characters are available based on the
   # currently available items and time periods.
   game.updateAvailableCharacters()

--- a/sourcefiles/logicwriter_chronosanity.py
+++ b/sourcefiles/logicwriter_chronosanity.py
@@ -268,7 +268,7 @@ def commitKeyItems(settings: rset.Settings,
     # piece of treasure. Treasure quality is based on the location's loot tier.
     for locationGroup in locationGroups:
         for location in locationGroup.getLocations():
-            if type(location) == logictypes.BaselineLocation and \
+            if isinstance(location, logictypes.BaselineLocation) and \
                (location not in chosenLocations):
 
                 # This is a baseline location without a key item.

--- a/sourcefiles/logicwriters.py
+++ b/sourcefiles/logicwriters.py
@@ -671,7 +671,7 @@ def commitKeyItems(settings: rset.Settings,
 
     for locationGroup in gameConfig.locationGroups:
         for location in locationGroup.getLocations():
-            if type(location) == logictypes.BaselineLocation and \
+            if isinstance(location, logictypes.BaselineLocation) and \
                (location not in chosenLocations):
 
                 # This is a baseline location without a key item.

--- a/sourcefiles/maps/mapmangler.py
+++ b/sourcefiles/maps/mapmangler.py
@@ -5,10 +5,7 @@ import ctenums
 import ctevent
 import ctrom
 
-import eventcommand
-import eventfunction
-
-from eventcommand import EventCommand as EC, FuncSync as FS, Operation as OP
+from eventcommand import EventCommand as EC
 from eventfunction import EventFunction as EF
 
 import freespace

--- a/sourcefiles/mystery.py
+++ b/sourcefiles/mystery.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 import copy
 import functools
-import typing
+from typing import Any, Dict, List
 
 import random
 import randosettings as rset
 
 
-def random_weighted_choice_from_dict(choice_dict: dict[typing.Any, int]):
+def random_weighted_choice_from_dict(choice_dict: Dict[Any, int]):
     '''Make a random choice from dict keys given weights in dict values.'''
     keys, weights = zip(*choice_dict.items())
     return random.choices(keys, weights, k=1)[0]
@@ -38,9 +38,10 @@ def generate_mystery_settings(base_settings: rset.Settings) -> rset.Settings:
     # blocks off boss scaling.
     mystery_flags = list(ms.flag_prob_dict.keys())
 
-    extra_flags = [flag for flag in list(GF)
-                   if flag in base_settings.gameflags
-                   and flag not in mystery_flags]
+    extra_flags: List[rset.GameFlags] = [
+        flag for flag in GF
+        if flag in base_settings.gameflags and flag not in mystery_flags
+    ]
 
     force_disabled_flags = rset.get_forced_off(ret_settings.game_mode)
     force_enabled_flags = rset.get_forced_on(ret_settings.game_mode)

--- a/sourcefiles/mystery.py
+++ b/sourcefiles/mystery.py
@@ -43,11 +43,11 @@ def generate_mystery_settings(base_settings: rset.Settings) -> rset.Settings:
         if flag in base_settings.gameflags and flag not in mystery_flags
     ]
 
-    force_disabled_flags = rset.get_forced_off(ret_settings.game_mode)
-    force_enabled_flags = rset.get_forced_on(ret_settings.game_mode)
+    force_disabled_flags = rset.ForcedFlags.get_forced_off(ret_settings.game_mode)
+    force_enabled_flags = rset.ForcedFlags.get_forced_on(ret_settings.game_mode)
     for flag in extra_flags:
-        force_disabled_flags |= rset.get_forced_off(flag)
-        force_enabled_flags |= rset.get_forced_on(flag)
+        force_disabled_flags |= rset.ForcedFlags.get_forced_off(flag)
+        force_enabled_flags |= rset.ForcedFlags.get_forced_on(flag)
 
     # Check that we don't have any conflicts here.
     assert (force_disabled_flags & force_enabled_flags) == GF(0)
@@ -68,8 +68,8 @@ def generate_mystery_settings(base_settings: rset.Settings) -> rset.Settings:
             raise ValueError('Error: ' + str(flag))
 
         if added_flag == flag:
-            force_disabled_flags |= rset.get_forced_off(flag)
-            force_enabled_flags |= rset.get_forced_on(flag)
+            force_disabled_flags |= rset.ForcedFlags.get_forced_off(flag)
+            force_enabled_flags |= rset.ForcedFlags.get_forced_on(flag)
             ret_flags |= flag
 
     # Switching from lits[GF] to just GF

--- a/sourcefiles/objectivehints.py
+++ b/sourcefiles/objectivehints.py
@@ -3,7 +3,7 @@ Module for turning text expressions into objective choices.
 '''
 from __future__ import annotations
 
-from typing import Dict, Tuple, Union
+from typing import Dict, Tuple
 
 import bossrandotypes as rotypes
 import objectivetypes

--- a/sourcefiles/randoconfig.py
+++ b/sourcefiles/randoconfig.py
@@ -4,7 +4,6 @@
 # GameConfig out to the rom.
 from __future__ import annotations
 import dataclasses
-import typing
 from typing import Optional, Union
 
 from treasures import treasuretypes
@@ -23,8 +22,6 @@ import ctenums
 import ctrom
 import ctstrings
 import techdb
-
-import randosettings as rset
 
 
 @dataclasses.dataclass

--- a/sourcefiles/randoconfig.py
+++ b/sourcefiles/randoconfig.py
@@ -184,16 +184,16 @@ class RandoConfig:
             objectives = []
         self.objectives = objectives
 
-    def _jot_json(self):
+    def to_jot_json(self):
         def enum_key_dict(d):
             "Properly uses str(key) for dicts with StrIntEnum keys."
             return { str(k): v for (k,v) in d.items() }
 
         def merged_list_dict(l):
-            """For things that are a list of objects, each having a _jot_json
+            """For things that are a list of objects, each having a to_jot_json
             method that returns a single-key dict, this merges those dicts into
             one."""
-            return {k: v for d in l for k, v in d._jot_json().items()}
+            return {k: v for d in l for k, v in d.to_jot_json().items()}
 
         def enum_enum_dict(d):
             "For dicts with both keys and values that are StrIntEnums"
@@ -221,7 +221,7 @@ class RandoConfig:
         boss_details_dict[str(BossID.BLACK_TYRANO)]['element'] = \
             str(bossrando.get_black_tyrano_element(self))
 
-        chars = self.pcstats._jot_json()
+        chars = self.pcstats.to_jot_json()
         # the below is ugly, would be nice to have tech lists on PlayerChar
         # objects maybe
         def get_tech_list(char_id: int, tech_db: techdb.TechDB):

--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -1354,8 +1354,13 @@ class Randomizer:
                 minus = pretty(minus_flags, indent=" - |", width=73)
                 diff += f"\n  - {minus}"
             file_object.write(textwrap.indent(f"{diff}\n", 7*" "))
-        pretty_cosmetics = pretty(self.settings.cosmetic_flags, indent=23*" "+"|")
-        file_object.write(f"Cosmetic: {pretty_cosmetics}\n\n")
+        if rset.GameFlags.BOSS_RANDO in self.settings.gameflags and self.settings.ro_settings.flags:
+            pretty_ro = pretty(self.settings.ro_settings.flags, indent=23*" "+"|")
+            file_object.write(f"RO Flags: {pretty_ro}\n")
+        if self.settings.cosmetic_flags:
+            pretty_cosmetics = pretty(self.settings.cosmetic_flags, indent=23*" "+"|")
+            file_object.write(f"Cosmetic: {pretty_cosmetics}\n")
+        file_object.write("\n")
 
     def write_consumable_spoilers(self, file_object):
         file_object.write("Consumable Properties\n")

--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -13,7 +13,7 @@ import typing
 from pathlib import Path
 from typing import Optional
 
-import arguments
+import cli.arguments as arguments
 import charassign
 import eventfunction
 

--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -3,13 +3,14 @@ The Chrono Trigger: Jets of Time Randomizer
 '''
 from __future__ import annotations
 
-import os
 import random
 import pickle
 import sys
 import json
 import textwrap
 import typing
+
+from pathlib import Path
 from typing import Optional
 
 import arguments
@@ -2229,30 +2230,28 @@ class Randomizer:
 
 class RandomizerWriter:
     '''Utility class for writing output/spoilers for Randomizer.'''
-    def __init__(self, rando: Randomizer, base_name: str):
+    def __init__(self, rando: Randomizer, base_name: Path):
         self.rando = rando
 
         flag_string = rando.settings.get_flag_string()
         seed = rando.settings.seed
         self.out_string = f"{base_name}.{flag_string}.{seed}"
 
-    def write_output_rom(self, output_path: str):
+    def write_output_rom(self, output_path: Path):
         out_name = f"{self.out_string}.sfc"
         self.out_rom = self.rando.get_generated_rom()
-        self.full_output_path = os.path.join(output_path, out_name)
+        self.full_output_path = output_path / out_name
+        self.full_output_path.write_bytes(self.out_rom)
 
-        with open(self.full_output_path, 'wb') as outfile:
-            outfile.write(self.out_rom)
-
-    def write_spoiler_log(self, output_path: str):
+    def write_spoiler_log(self, output_path: Path):
         spoiler_name = f"{self.out_string}.spoilers.txt"
-        self.spoiler_path = os.path.join(output_path, spoiler_name)
-        self.rando.write_spoiler_log(self.spoiler_path)
+        self.spoiler_path = output_path / spoiler_name
+        self.rando.write_spoiler_log(str(self.spoiler_path))
 
-    def write_json_spoiler_log(self, output_path: str):
+    def write_json_spoiler_log(self, output_path: Path):
         json_spoiler_name = f"{self.out_string}.spoilers.json"
-        self.json_spoiler_path = os.path.join(output_path, json_spoiler_name)
-        self.rando.write_json_spoiler_log(self.json_spoiler_path)
+        self.json_spoiler_path = output_path / json_spoiler_name
+        self.rando.write_json_spoiler_log(str(self.json_spoiler_path))
 
 
 def read_names():
@@ -2265,29 +2264,23 @@ def read_names():
 
 def main():
     parser = arguments.get_parser()
-    arg_namespace = parser.parse_args()
-    val_dict = vars(arg_namespace)
+    args = parser.parse_args()
 
-    input_file = val_dict['input_file']
-    output_path = val_dict['output_path']
-
-    if not os.path.isfile(input_file):
+    if not args.input_file.exists():
         raise FileNotFoundError("Invalid input file path.")
 
-    if output_path is None:
-        output_path = os.path.dirname(input_file)
-    elif not os.path.isdir(output_path):
+    if args.output_path is None:
+        args.output_path = args.input_file.parent
+    if not args.output_path.is_dir():
         raise FileNotFoundError("Invalid output directory.")
 
     # Make sure the settings are ok before going further and reading the rom.
-    settings = arguments.args_to_settings(arg_namespace)
+    settings = arguments.args_to_settings(args)
     if settings.seed is None or settings.seed == "":
         names = read_names()
         settings.seed = "".join(random.choice(names) for i in range(2))
 
-    with open(input_file, 'rb') as infile:
-        rom = infile.read()
-
+    rom = args.input_file.read_bytes()
     if not CTRom.validate_ct_rom_bytes(rom):
         print(
             'Warning: File provided is not a vanilla CT ROM.  Proceed '
@@ -2297,21 +2290,20 @@ def main():
         if not proceed:
             sys.exit()
 
-    rando = Randomizer(rom, is_vanilla=False,
-                       settings=settings, config=None)
+    rando = Randomizer(rom, is_vanilla=False, settings=settings, config=None)
     rando.set_random_config()
 
-    base_name = os.path.basename(input_file)
+    base_name = args.input_file.parts[-1]
     writer = RandomizerWriter(rando, base_name=base_name)
-    writer.write_output_rom(output_path)
+    writer.write_output_rom(args.output_path)
     print(f"output ROM: {writer.full_output_path}")
 
-    if val_dict['spoilers']:
-        writer.write_spoiler_log(output_path)
+    if args.spoilers:
+        writer.write_spoiler_log(args.output_path)
         print(f"spoilers: {writer.spoiler_path}")
 
-    if val_dict['json_spoilers']:
-        writer.write_json_spoiler_log(output_path)
+    if args.json_spoilers:
+        writer.write_json_spoiler_log(args.output_path)
         print(f"json spoilers: {writer.json_spoiler_path}")
 
 

--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -1297,8 +1297,8 @@ class Randomizer:
                     ", ".join([str(CharID(i))
                                for i in (set(range(7)) - set(choicelist))])
 
-        chars = {c: summarize_single(self.settings.char_choices[c])
-                 for c in range(len(self.settings.char_choices))}
+        chars = {c: summarize_single(self.settings.char_settings.choices[c])
+                 for c in range(len(self.settings.char_settings.choices))}
         rv = ""
         for c in sorted(chars.keys()):
             if chars[c] != "Any":
@@ -1333,7 +1333,7 @@ class Randomizer:
                 f"Speed {tab_set.speed_min}-{tab_set.speed_max}\n"
             )
         if rset.GameFlags.CHAR_RANDO in gf and \
-           self.settings.char_choices != rset.Settings().char_choices:
+           self.settings.char_settings.choices != rset.Settings().char_settings.choices:
 
             dupes = self._summarize_dupes()
             file_object.write(f"Characters: {dupes}\n")
@@ -1924,7 +1924,7 @@ class Randomizer:
             cosmetichacks.death_peak_singing_mountain_music(ctrom, settings)
 
         cosmetichacks.set_pc_names(
-            ctrom, *settings.char_names
+            ctrom, *settings.char_settings.names
         )
 
         if rset.CosmeticFlags.REDUCE_FLASH in cos_flags:

--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -11,7 +11,7 @@ import textwrap
 import typing
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import cli.arguments as arguments
 import charassign
@@ -101,6 +101,8 @@ class Randomizer:
         rando.generate_rom()
         out_rom = rando.get_generated_rom()
     '''
+    _pickles_path: Path = Path(__file__).parent / 'pickles'
+
     def __init__(self, rom: bytes, is_vanilla: bool = True,
                  settings: Optional[rset.Settings] = None,
                  config: Optional[cfg.RandoConfig] = None):
@@ -190,11 +192,11 @@ class Randomizer:
         # provided.  You just have to make sure to redump any time time that
         # base_patch.ips or hard.ips change.  Demo below.
         '''
-        with open('./pickles/default_randoconfig.pickle', 'rb') as infile:
+        with self._get_pickle_path('default_randoconfig.pickle').open('rb') as infile:
             self.config = pickle.load(infile)
 
         if self.settings.enemy_difficulty == rset.Difficulty.HARD:
-            with open('./pickles/enemy_dict_hard.pickle', 'rb') as infile:
+            with self._get_pickle_path('enemy_dict_hard.pickle').open('rb') as infile:
                 self.config.enemy_dict = pickle.load(infile)
         '''
 
@@ -1947,7 +1949,7 @@ class Randomizer:
         cls.fill_default_config_entries(config)
         config.update_from_ct_rom(ct_rom)
 
-        with open('./pickles/default_randoconfig.pickle', 'wb') as outfile:
+        with Randomizer._get_pickle_path('default_randoconfig.pickle').open('wb') as outfile:
             pickle.dump(config, outfile)
 
     @classmethod
@@ -2227,6 +2229,11 @@ class Randomizer:
         rando.generate_rom()
         return rando.get_generated_rom()
 
+    @staticmethod
+    def _get_pickle_path(filename: Union[str, Path]) -> Path:
+        '''Get path to pickle from "pickles" directory in package.'''
+        return Randomizer._pickles_path / filename
+
 
 class RandomizerWriter:
     '''Utility class for writing output/spoilers for Randomizer.'''
@@ -2255,10 +2262,9 @@ class RandomizerWriter:
 
 
 def read_names():
-    p = open("names.txt", "r")
-    names = p.readline()
-    names = names.split(",")
-    p.close()
+    names_path = Path(__file__).parent / 'names.txt'
+    with names_path.open('r') as p:
+        names = p.readline().split(',')
     return names
 
 

--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -3,7 +3,6 @@ The Chrono Trigger: Jets of Time Randomizer
 '''
 from __future__ import annotations
 
-import copy
 import os
 import random
 import pickle

--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -1278,9 +1278,8 @@ class Randomizer:
                 self.write_json_spoiler_log(real_outfile)
         else:
             json.dump(
-                {"configuration": self.config,
-                 "settings": self.settings},
-                outfile, cls=JOTJSONEncoder
+                {"configuration": self.config, "settings": self.settings},
+                outfile, cls=JOTJSONEncoder, indent=2
             )
 
     def _summarize_dupes(self):

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -76,7 +76,7 @@ class CreateToolTip(object):
         self.tw.wm_overrideredirect(True)
         self.tw.wm_geometry("+%d+%d" % (x, y))
         displaytext = self.text
-        if type(self.text) == tk.StringVar:
+        if isinstance(self.text, tk.StringVar):
             displaytext = self.text.get()
         label = tk.Label(self.tw, text=displaytext, justify='left',
                          background="#ffffff", relief='solid', borderwidth=1,

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -2086,7 +2086,7 @@ class RandoGUI:
         checkbox = tk.Checkbutton(
             extraoptionframe,
             text='Boss Spot HPs',
-            variable=self.flag_dict[GameFlags.BOSS_SPOT_HP]
+            variable=self.ro_flag_dict[ROFlags.BOSS_SPOT_HP]
         )
         checkbox.pack(anchor=tk.W)
 

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -439,11 +439,11 @@ class RandoGUI:
         loc_list = [self.boss_locations[i]
                     for i in self.boss_location_listbox.curselection()]
 
-        self.settings.ro_settings = ROSettings(
-            loc_list,
-            boss_list,
-            False
-        )
+        if loc_list:
+            roset = ROSettings(loc_list, boss_list, False)
+        else:
+            roset = ROSettings.from_game_mode(self.settings.game_mode, bosses=boss_list)
+        self.settings.ro_settings = roset
         self.settings.ro_settings.flags = \
             reduce(lambda a, b: a | b, ro_flags, ROFlags(False))
 

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -1415,7 +1415,7 @@ class RandoGUI:
         for action, button in self.controller_binds.items():
             try:
                 value = InputMap[button.get().upper().replace(' ', '_')]
-            except:
+            except Exception:
                 messagebox.showerror(
                     'Options Controller Error',
                     'All button binds must be set.'
@@ -2710,25 +2710,12 @@ class RandoGUI:
             and assignment dropdowns.
             '''
 
-            # Initially populate the list.
-            ret = [str(x) for x in InputMap]
-
             # Get the assigned buttons.
             assigned = [
                 y.get() for x, y in binds.items() if y.get() != 'Unset'
             ]
 
-            for x in InputMap:
-                # Force strings to enable comparisons;
-                # StringVars only output str, not StrIntEnum
-                x = str(x)
-                try:
-                    if x in assigned:
-                        ret.remove(x)
-                except:  # TODO: Figure out what exceptions are raised.
-                    pass
-
-            return ret
+            return [str(x) for x in InputMap if str(x) not in assigned]
 
         def _update_display_pg(pg_strs):
             '''

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -3016,4 +3016,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -1729,8 +1729,8 @@ class RandoGUI:
                 if self.output_dir is None or self.output_dir.get() == '':
                     self.output_dir.set(str(input_path.parent))
 
-                base_name = input_path.name.split('.')[0]
-                out_dir = self.output_dir.get()
+                base_name = pathlib.Path(input_path.name.split('.')[0])
+                out_dir = pathlib.Path(self.output_dir.get())
 
                 writer = randomizer.RandomizerWriter(rando, base_name=base_name)
                 writer.write_output_rom(out_dir)

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -19,7 +19,7 @@ import randomizer
 import bossrandotypes as rotypes
 from randosettings import Settings, GameFlags, Difficulty, ShopPrices, \
     TechOrder, TabSettings, TabRandoScheme, ROSettings, ROFlags, \
-    CosmeticFlags, GameMode, MysterySettings
+    CosmeticFlags, GameMode, MysterySettings, CharNames
 from ctenums import ActionMap, InputMap
 import ctoptions
 import ctrom
@@ -279,7 +279,7 @@ class RandoGUI:
 
     def set_settings(self, new_settings: Settings):
         self.__settings = new_settings
-        # print(self.__settings.char_choices)
+        # print(self.__settings.char_settings.choices)
         # print(self.__settings.gameflags)
         # print(self.__settings.get_flag_string())
         self.update_gui_vars()
@@ -400,14 +400,8 @@ class RandoGUI:
             value = InputMap[button.get().upper().replace(' ', '_')]
             self.settings.ctoptions.controller_binds.mappings[action] = value
 
-        self.settings.char_names[0] = self.char_names['Crono'].get()
-        self.settings.char_names[1] = self.char_names['Marle'].get()
-        self.settings.char_names[2] = self.char_names['Lucca'].get()
-        self.settings.char_names[3] = self.char_names['Robo'].get()
-        self.settings.char_names[4] = self.char_names['Frog'].get()
-        self.settings.char_names[5] = self.char_names['Ayla'].get()
-        self.settings.char_names[6] = self.char_names['Magus'].get()
-        self.settings.char_names[7] = self.char_names['Epoch'].get()
+        for name in CharNames.default():
+            self.settings.char_settings.names[name] = self.char_names[name].get()
 
         self.settings.gameflags = \
             reduce(lambda a, b: a | b, flags, GameFlags(False))
@@ -432,10 +426,10 @@ class RandoGUI:
 
         # RC (dup duals already taken, just char choices)
         for i in range(7):
-            self.settings.char_choices[i] = []
+            self.settings.char_settings.choices[i] = []
             for j in range(7):
                 if self.char_choices[i][j].get() == 1:
-                    self.settings.char_choices[i].append(j)
+                    self.settings.char_settings.choices[i].append(j)
 
         # RO Settings
         # print(self.bosses)
@@ -507,14 +501,8 @@ class RandoGUI:
                 self.cosmetic_flag_dict[x].set(0)
 
         # Char names
-        self.char_names['Crono'].set(self.settings.char_names[0])
-        self.char_names['Marle'].set(self.settings.char_names[1])
-        self.char_names['Lucca'].set(self.settings.char_names[2])
-        self.char_names['Robo'].set(self.settings.char_names[3])
-        self.char_names['Frog'].set(self.settings.char_names[4])
-        self.char_names['Ayla'].set(self.settings.char_names[5])
-        self.char_names['Magus'].set(self.settings.char_names[6])
-        self.char_names['Epoch'].set(self.settings.char_names[7])
+        for name in CharNames.default():
+            self.char_names[name].set(self.settings.char_settings.names[name])
 
         increment_vars = [
             'menu_background',
@@ -567,7 +555,7 @@ class RandoGUI:
         # RC char choices
         for i in range(7):
             for j in range(7):
-                if j in self.settings.char_choices[i]:
+                if j in self.settings.char_settings.choices[i]:
                     self.char_choices[i][j].set(1)
                 else:
                     self.char_choices[i][j].set(0)
@@ -826,9 +814,7 @@ class RandoGUI:
         row = 0
         col = 0
 
-        char_names = [
-            'Crono', 'Marle', 'Lucca', 'Robo', 'Frog', 'Ayla', 'Magus'
-        ]
+        char_names = CharNames.default()[:-1]
 
         row += 1
 

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -5,7 +5,6 @@ import os
 import pathlib
 import pickle
 import random
-import sys
 import threading
 import tkinter as tk
 from tkinter import ttk
@@ -19,13 +18,12 @@ import randomizer
 import bossrandotypes as rotypes
 from randosettings import Settings, GameFlags, Difficulty, ShopPrices, \
     TechOrder, TabSettings, TabRandoScheme, ROSettings, ROFlags, \
-    CosmeticFlags, BucketSettings, GameMode, MysterySettings
-from ctenums import LocID, ActionMap, InputMap
+    CosmeticFlags, GameMode, MysterySettings
+from ctenums import ActionMap, InputMap
 import ctoptions
 import ctrom
 import ctstrings
 
-import objectivehints as oh
 
 #
 # tkinter does not have a native tooltip implementation.

--- a/sourcefiles/randomizergui.py
+++ b/sourcefiles/randomizergui.py
@@ -11,6 +11,7 @@ from tkinter import ttk
 from tkinter.filedialog import askopenfilename
 from tkinter.filedialog import askdirectory
 from tkinter import messagebox
+from typing import Optional
 
 # custom/local libraries
 import bucketgui
@@ -2768,7 +2769,7 @@ class RandoGUI:
             #update listbox in another frame
             parent.listbox_values.set(options)
             
-        def _construct_callback(action: ActionMap = None):
+        def _construct_callback(action: Optional[ActionMap] = None):
             '''
             Constructs callback function for gui usage.
             '''

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -19,6 +19,10 @@ class StrIntEnum(IntEnum):
         return x
 
     @classmethod
+    def default(cls):
+        raise NotImplementedError(f"No .default implemented for {cls}")
+
+    @classmethod
     def str_dict(cls: Type[SIE]) -> dict[SIE, str]:
         enum_list: list[SIE] = list(cls)
         return dict((x, str(x)) for x in enum_list)
@@ -38,17 +42,29 @@ class GameMode(StrIntEnum):
     LEGACY_OF_CYRUS = auto()
     VANILLA_RANDO = auto()
 
+    @classmethod
+    def default(_):
+        return GameMode.STANDARD
+
 
 class Difficulty(StrIntEnum):
     EASY = 0
     NORMAL = 1
     HARD = 2
 
+    @classmethod
+    def default(_):
+        return Difficulty.NORMAL
+
 
 class TechOrder(StrIntEnum):
     NORMAL = 0
     FULL_RANDOM = 1
     BALANCED_RANDOM = 2
+
+    @classmethod
+    def default(_):
+        return TechOrder.FULL_RANDOM
 
 
 class ShopPrices(StrIntEnum):
@@ -57,8 +73,18 @@ class ShopPrices(StrIntEnum):
     FULLY_RANDOM = 2
     FREE = 3
 
+    @classmethod
+    def default(_):
+        return ShopPrices.NORMAL
+
 
 class SerializableFlag(Flag):
+    def __add__(self, other: Flag):
+        return self | other
+
+    def __sub__(self, other: Flag):
+        return self & ~other
+
     def to_jot_json(self) -> List[str]:
         return [str(flag) for flag in type(self) if flag in self]
 
@@ -105,12 +131,6 @@ class GameFlags(SerializableFlag):
     REMOVE_BLACK_OMEN_SPOT = auto()
     # No longer Logic Tweak Flags
     TECH_DAMAGE_RANDO = auto()
-
-    def __add__(self, other: GameFlags):
-        return self | other
-
-    def __sub__(self, other: GameFlags):
-        return self & ~other
 
 
 # Dictionary for what flags force what other flags off.
@@ -217,10 +237,14 @@ class TabRandoScheme(StrIntEnum):
     UNIFORM = 0
     BINOMIAL = 1
 
+    @classmethod
+    def default(_):
+        return TabRandoScheme.UNIFORM
+
 
 @dataclass
 class TabSettings:
-    scheme: TabRandoScheme = TabRandoScheme.UNIFORM
+    scheme: TabRandoScheme = TabRandoScheme.default()
     binom_success: float = 0.5  # Only used by binom if set
     power_min: int = 2
     power_max: int = 4
@@ -388,12 +412,12 @@ class Settings:
 
     def __init__(self):
 
-        self.game_mode = GameMode.STANDARD
-        self.item_difficulty = Difficulty.NORMAL
-        self.enemy_difficulty = Difficulty.NORMAL
+        self.game_mode = GameMode.default()
+        self.item_difficulty = Difficulty.default()
+        self.enemy_difficulty = Difficulty.default()
 
-        self.techorder = TechOrder.FULL_RANDOM
-        self.shopprices = ShopPrices.NORMAL
+        self.techorder = TechOrder.default()
+        self.shopprices = ShopPrices.default()
 
         self.mystery_settings = MysterySettings()
 

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -317,7 +317,7 @@ class CharChoices(UserList):
 
         if choices:
             for pc_id, choice in enumerate(choices):
-                self.data[pc_id] = choice
+                self[pc_id] = choice
 
     def __getitem__(self, key):
         '''Lookup items via characer name string or index.'''

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -116,7 +116,6 @@ class GameFlags(SerializableFlag):
     GEAR_RANDO = auto()
     STARTERS_SUFFICIENT = auto()
     EPOCH_FAIL = auto()
-    BOSS_SPOT_HP = auto()
     # Logic Tweak flags from VanillaRando mode
     UNLOCKED_SKYGATES = auto()
     ADD_SUNKEEP_SPOT = auto()
@@ -242,21 +241,15 @@ class ROSettings:
     Full Boss Rando settings allow specification of which bosses/spots are
     in the pool as well as some additional flags.
     '''
-    spots: list[rotypes.BossSpotID] = field(default_factory=list)
-    bosses: list[rotypes.BossID] = field(default_factory=list)
+    spots: List[rotypes.BossSpotID] = field(default_factory=list)
+    bosses: List[rotypes.BossID] = field(default_factory=list)
     flags: ROFlags = ROFlags(0)
 
-    @classmethod
+    @staticmethod
     def from_game_mode(
-            cls,
-            mode: GameMode,
-            boss_list: Optional[list[rotypes.BossID]] = None,
-            ro_flags: ROFlags = ROFlags(0)
-            ) -> ROSettings:
-        '''
-        Construct an ROSettings object with correct initial locations given
-        the game mode.
-        '''
+        mode: GameMode, bosses: Optional[List[rotypes.BossID]] = None, flags: ROFlags = ROFlags(0)
+    ) -> ROSettings:
+        '''Construct an ROSettings object with correct initial locations given the game mode.'''
         spots = []
         BS = rotypes.BossSpotID
         if mode == GameMode.LOST_WORLDS:
@@ -280,10 +273,10 @@ class ROSettings:
         else:  # Std, IA, Vanilla
             spots = list(BS)
 
-        if boss_list is None:
-            boss_list = rotypes.get_assignable_bosses()
+        if not bosses:
+            bosses = rotypes.get_assignable_bosses()
 
-        return ROSettings(spots, boss_list, ro_flags)
+        return ROSettings(spots, bosses, flags)
 
     def to_jot_json(self) -> Dict[str, Any]:
         data = {}
@@ -643,9 +636,10 @@ class Settings:
 
         ret.gameflags = (
             GF.FIX_GLITCH | GF.ZEAL_END | GF.FAST_PENDANT | GF.BOSS_RANDO |
-            GF.BOSS_SPOT_HP | GF.FAST_TABS | GF.FREE_MENU_GLITCH |
+            GF.FAST_TABS | GF.FREE_MENU_GLITCH |
             GF.GEAR_RANDO | GF.HEALING_ITEM_RANDO
         )
+        ret.ro_settings.flags = ROFlags.BOSS_SPOT_HP
 
         return ret
 

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -138,92 +138,60 @@ class GameFlags(SerializableFlag):
 # Note that this is NOT symmetric.  For example Lost Worlds will force
 # Boss Scaling off, but not vice versa because it's annoying to have to
 # click off every minor flag to select a major flag like a game mode.
-_GF = GameFlags
-_GM = GameMode
-_forced_off_dict: dict[Union[_GF, _GM], _GF] = {
-    _GF.FIX_GLITCH: _GF(0),
-    _GF.BOSS_SCALE: _GF(0),
-    _GF.ZEAL_END: _GF(0),
-    _GF.FAST_PENDANT: _GF(0),
-    _GF.LOCKED_CHARS: _GF(0),
-    _GF.UNLOCKED_MAGIC: _GF(0),
-    _GF.CHRONOSANITY: _GF.BOSS_SCALE,
-    _GF.ROCKSANITY: _GF(0),
-    _GF.TAB_TREASURES: _GF(0),
-    _GF.BOSS_RANDO: _GF(0),
-    _GF.CHAR_RANDO: _GF(0),
-    _GF.DUPLICATE_CHARS: _GF(0),
-    _GF.DUPLICATE_TECHS: _GF(0),
-    _GF.VISIBLE_HEALTH: _GF(0),
-    _GF.FAST_TABS: _GF(0),
-    _GF.BUCKET_LIST: _GF(0),
-    _GF.MYSTERY: _GF(0),
-    _GF.GEAR_RANDO: _GF(0),
-    _GF.HEALING_ITEM_RANDO: _GF(0),
-    _GF.EPOCH_FAIL: _GF(0),
-    _GM.STANDARD: _GF(0),
-    _GM.LOST_WORLDS: (
-        _GF.BOSS_SCALE | _GF.BUCKET_LIST | _GF.EPOCH_FAIL |
-        _GF.ADD_BEKKLER_SPOT | _GF.ADD_CYRUS_SPOT | _GF.ADD_OZZIE_SPOT |
-        _GF.ADD_RACELOG_SPOT | _GF.ADD_SUNKEEP_SPOT | _GF.RESTORE_JOHNNY_RACE |
-        _GF.SPLIT_ARRIS_DOME | _GF.RESTORE_TOOLS | _GF.UNLOCKED_SKYGATES |
-        _GF.VANILLA_DESERT | _GF.VANILLA_ROBO_RIBBON | _GF.ROCKSANITY |
-        _GF.REMOVE_BLACK_OMEN_SPOT
-    ),
-    _GM.ICE_AGE: (
-        _GF.ZEAL_END |
-        _GF.BOSS_SCALE | _GF.BUCKET_LIST |
-        _GF.ADD_BEKKLER_SPOT
-    ),
-    _GM.LEGACY_OF_CYRUS: (
-        _GF.ZEAL_END |
-        _GF.BUCKET_LIST | _GF.BOSS_SCALE |
-        _GF.ADD_OZZIE_SPOT | _GF.ADD_SUNKEEP_SPOT | _GF.RESTORE_TOOLS |
-        _GF.RESTORE_JOHNNY_RACE | _GF.SPLIT_ARRIS_DOME | _GF.ADD_RACELOG_SPOT |
-        _GF.ADD_BEKKLER_SPOT
-    ),
-    _GM.VANILLA_RANDO: (
-        _GF.BOSS_SCALE
-    )
-}
+class ForcedFlags:
+    _GF = GameFlags
+    _GM = GameMode
+
+    forced_off: Dict[Union[GameFlags, GameMode], GameFlags] = {
+        _GF.CHRONOSANITY: _GF.BOSS_SCALE,
+        _GM.LOST_WORLDS: (
+            _GF.BOSS_SCALE | _GF.BUCKET_LIST | _GF.EPOCH_FAIL |
+            _GF.ADD_BEKKLER_SPOT | _GF.ADD_CYRUS_SPOT | _GF.ADD_OZZIE_SPOT |
+            _GF.ADD_RACELOG_SPOT | _GF.ADD_SUNKEEP_SPOT | _GF.RESTORE_JOHNNY_RACE |
+            _GF.SPLIT_ARRIS_DOME | _GF.RESTORE_TOOLS | _GF.UNLOCKED_SKYGATES |
+            _GF.VANILLA_DESERT | _GF.VANILLA_ROBO_RIBBON | _GF.ROCKSANITY |
+            _GF.REMOVE_BLACK_OMEN_SPOT
+        ),
+        _GM.ICE_AGE: (
+            _GF.ZEAL_END |
+            _GF.BOSS_SCALE | _GF.BUCKET_LIST |
+            _GF.ADD_BEKKLER_SPOT
+        ),
+        _GM.LEGACY_OF_CYRUS: (
+            _GF.ZEAL_END |
+            _GF.BUCKET_LIST | _GF.BOSS_SCALE |
+            _GF.ADD_OZZIE_SPOT | _GF.ADD_SUNKEEP_SPOT | _GF.RESTORE_TOOLS |
+            _GF.RESTORE_JOHNNY_RACE | _GF.SPLIT_ARRIS_DOME | _GF.ADD_RACELOG_SPOT |
+            _GF.ADD_BEKKLER_SPOT
+        ),
+        _GM.VANILLA_RANDO: _GF.BOSS_SCALE,
+    }
+
+    # Similar dictionary for forcing flags on
+    forced_on: Dict[Union[GameFlags, GameMode], GameFlags] = {
+        _GF.ROCKSANITY: _GF.UNLOCKED_SKYGATES,
+        _GF.DUPLICATE_CHARS: _GF.CHAR_RANDO,
+        _GF.DUPLICATE_TECHS: (_GF.CHAR_RANDO | _GF.DUPLICATE_CHARS),
+        _GM.LOST_WORLDS: _GF.UNLOCKED_MAGIC,
+        _GM.ICE_AGE: _GF.UNLOCKED_MAGIC,
+        _GM.LEGACY_OF_CYRUS: _GF.UNLOCKED_MAGIC,
+    }
 
 
-# Similar dictionary for forcing flags on
-_forced_on_dict = {
-    _GF.FIX_GLITCH: _GF(0),
-    _GF.BOSS_SCALE: _GF(0),
-    _GF.ZEAL_END: _GF(0),
-    _GF.FAST_PENDANT: _GF(0),
-    _GF.LOCKED_CHARS: _GF(0),
-    _GF.UNLOCKED_MAGIC: _GF(0),
-    _GF.CHRONOSANITY: _GF(0),
-    _GF.ROCKSANITY: _GF.UNLOCKED_SKYGATES,
-    _GF.TAB_TREASURES: _GF(0),
-    _GF.BOSS_RANDO: _GF(0),
-    _GF.CHAR_RANDO: _GF(0),
-    _GF.DUPLICATE_CHARS: _GF.CHAR_RANDO,
-    _GF.DUPLICATE_TECHS: (_GF.CHAR_RANDO | _GF.DUPLICATE_CHARS),
-    _GF.VISIBLE_HEALTH: _GF(0),
-    _GF.FAST_TABS: _GF(0),
-    _GF.BUCKET_LIST: _GF(0),
-    _GF.MYSTERY: _GF(0),
-    _GF.GEAR_RANDO: _GF(0),
-    _GF.HEALING_ITEM_RANDO: _GF(0),
-    _GF.EPOCH_FAIL: _GF(0),
-    _GM.STANDARD: _GF(0),
-    _GM.LOST_WORLDS: _GF.UNLOCKED_MAGIC,
-    _GM.ICE_AGE: _GF.UNLOCKED_MAGIC,
-    _GM.LEGACY_OF_CYRUS: _GF.UNLOCKED_MAGIC,
-    _GM.VANILLA_RANDO: _GF(0)
-}
+    @classmethod
+    def get_forced_off(cls, flag: Union[GameFlags, GameMode]) -> GameFlags:
+        return cls.forced_off.get(flag, GameFlags(0))
 
+    @classmethod
+    def get_forced_on(cls, flag: Union[GameFlags, GameMode]) -> GameFlags:
+        return cls.forced_on.get(flag, GameFlags(0))
 
-def get_forced_off(flag: Union[GameFlags, GameMode]) -> GameFlags:
-    return _forced_off_dict.get(flag, GameFlags(0))
-
-
-def get_forced_on(flag: Union[GameFlags, GameMode]) -> GameFlags:
-    return _forced_on_dict.get(flag, GameFlags(0))
+    @classmethod
+    def to_jot_json(cls) -> Dict[str, Any]:
+        return {
+            'forced_off': {str(k): v for k, v in cls.forced_off.items()},
+            'forced_on': {str(k): v for k, v in cls.forced_on.items()},
+        }
 
 
 class CosmeticFlags(SerializableFlag):
@@ -704,7 +672,7 @@ class Settings:
         from resolveExtraKeyItems, if possible.
         '''
         mode = self.game_mode
-        forced_off = _forced_off_dict[mode]
+        forced_off = ForcedFlags.get_forced_off(mode)
         self.gameflags &= ~forced_off
 
         # Duplicate Character implies Character Rando
@@ -769,8 +737,7 @@ class Settings:
                 self.gameflags &= ~GameFlags.EPOCH_FAIL
                 added_kis -= 1
             else:
-                raise ValueError('Cannot fix flag conflicts')
-
+                raise ValueError(f"Cannot fix flag conflicts: {added_kis} KIs > {added_spots} spots")
 
 
     def get_flag_string(self):

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import random
 from collections import UserList
 from enum import Flag, IntEnum, auto
 from dataclasses import dataclass, field, fields
@@ -275,6 +276,11 @@ class ROSettings:
 
         if not bosses:
             bosses = rotypes.get_assignable_bosses()
+        # if bosses specified, and not enough bosses for spots, assure any specified bosses are included,
+        # but randomly take enough other assignable bosses to fill all spots
+        elif (padding_needed := len(spots) - len(bosses)) > 0:
+            assignable = [boss for boss in rotypes.get_assignable_bosses() if boss not in bosses]
+            bosses.extend(random.sample(assignable, k=padding_needed))
 
         return ROSettings(spots, bosses, flags)
 
@@ -480,7 +486,6 @@ class MysterySettings:
 
     def __str__(self) -> str:
         return '\n'.join(str(self[field.name]) for field in fields(self)) + '\n'
-
 
 
 @dataclass

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 from enum import Flag, IntEnum, auto
 from dataclasses import dataclass, field
-from typing import Callable, Union, Optional, Tuple, Type, TypeVar
+from typing import Callable, Union, Mapping, Optional, Sequence, Tuple, Type, TypeVar
 
 import bossrandotypes as rotypes
 import ctoptions
 
+JSONPrimitive = Optional[Union[int, float, bool, str]]
+JSONType = Union[JSONPrimitive, Mapping[str, "JSONType"], Sequence["JSONType"]]
 SIE = TypeVar('SIE', bound='StrIntEnum')
 
 
@@ -190,11 +192,11 @@ _forced_on_dict = {
 }
 
 
-def get_forced_off(flag: GameFlags) -> GameFlags:
+def get_forced_off(flag: Union[GameFlags, GameMode]) -> GameFlags:
     return _forced_off_dict.get(flag, GameFlags(0))
 
 
-def get_forced_on(flag: GameFlags) -> GameFlags:
+def get_forced_on(flag: Union[GameFlags, GameMode]) -> GameFlags:
     return _forced_on_dict.get(flag, GameFlags(0))
 
 

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
+from collections import UserList
 from enum import Flag, IntEnum, auto
 from dataclasses import dataclass, field, fields
-from typing import Any, Callable, Dict, List, Union, Mapping, Optional, Sequence, Tuple, Type, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, Union, Mapping, Optional, Sequence, Tuple, Type, TypeVar
 
 import bossrandotypes as rotypes
 import ctoptions
@@ -341,6 +342,113 @@ class BucketSettings:
         return {field.name: getattr(self, field.name) for field in fields(self)}
 
 
+class CharChoices(UserList):
+    '''Type-checked list of lists for character choices allowing get/set via string or index.'''
+
+    def __init__(self, choices: Optional[List[Union[str, List[int]]]] = None):
+        self.data = [list(range(7)) for _ in range(7)]
+
+        if choices:
+            for pc_id, choice in enumerate(choices):
+                self.data[pc_id] = choice
+
+    def __getitem__(self, key):
+        '''Lookup items via characer name string or index.'''
+        return self.data[CharNames.lookup(key)]
+
+    def __setitem__(self, key, choices):
+        '''Set items via character name string or index.
+
+        When choices is a string, parse to determine character choice ints.
+        Otherwise, item must be a list of ints, or raise TypeError.
+        '''
+        index = CharNames.lookup(key)
+        if isinstance(choices, str):
+            self.data[index] = self._parse_choices(choices)
+        elif isinstance(choices, List) and all(isinstance(x, int) for x in choices):
+            self.data[index] = choices
+        else:
+            raise TypeError('Character choices must be either string or list of ints.')
+
+    @staticmethod
+    def _parse_choices(choices: str) -> List[int]:
+        '''Determine list of character choice ints based on specified string.'''
+        selections = choices.lower().split()
+
+        # select all character choices
+        if selections[0] == 'all':
+            return list(range(7))
+
+        # inverted selection: get all character choices except specified
+        if selections[0] == 'not':
+            indices = [CharNames.lookup(choice) for choice in selections[1:]]
+            return [index for index in range(7) if index not in indices]
+
+        # regular selection: get all character choices specified
+        indices = [CharNames.lookup(choice) for choice in selections]
+        return [index for index in range(7) if index in indices]
+
+    def to_jot_json(self) -> List[List[int]]:
+        def _choices(choices):
+            if isinstance(choices, str):
+                return choices
+            else:
+                return [choice for choice in choices]
+        return [_choices(character) for character in self.data]
+
+
+class CharNames(UserList):
+    '''Type-checked list of character names allowing get/set via string or index.'''
+
+    def __init__(self, names: Optional[Iterable[str]] = None):
+        names = [name for name in names] if names else []
+        if not names:
+            names = self.default()
+        if len(names) != 8:
+            raise IndexError('Must specify 8 names if using assignment.')
+        if not all(isinstance(name, str) for name in names):
+            raise TypeError('All character names must be strings.')
+        self.data = names
+
+    def __getitem__(self, key):
+        '''Lookup items via characer name string or index.'''
+        return self.data[self.lookup(key)]
+
+    def __setitem__(self, key, name):
+        '''Set items via character name string or index.'''
+        if not isinstance(name, str):
+            raise TypeError('Character names must be strings.')
+        self.data[self.lookup(key)] = name
+
+    @staticmethod
+    def default() -> List[str]:
+        '''Default character names.'''
+        return ['Crono', 'Marle', 'Lucca', 'Robo', 'Frog', 'Ayla', 'Magus', 'Epoch']
+
+    @staticmethod
+    def lookup(key) -> int:
+        if isinstance(key, str):
+            return CharNames.default().index(key.lower().capitalize())
+        return key
+
+    def to_jot_json(self) -> List[str]:
+        return [name for name in self.data]
+
+
+@dataclass
+class CharSettings:
+    '''Contains settings related to characters.'''
+    names: CharNames
+    choices: CharChoices
+
+    def __init__(self):
+        self.names = CharNames()
+        self.choices = CharChoices()
+
+    def to_jot_json(self) -> Dict[str, JSONType]:
+        return {field.name: getattr(self, field.name) for field in fields(self)}
+
+
 class MysterySettings:
     def __init__(self):
         self.game_mode_freqs: dict[GameMode, int] = {
@@ -423,22 +531,16 @@ class Settings:
 
         self.gameflags = GameFlags(0)
         self.initial_flags = GameFlags(0)
-        self.char_choices = [list(range(7)) for j in range(7)]
 
         self.ro_settings = ROSettings.from_game_mode(self.game_mode)
         self.bucket_settings = BucketSettings()
-
+        self.char_settings = CharSettings()
         self.tab_settings = TabSettings()
         self.cosmetic_flags = CosmeticFlags(0)
 
         self.ctoptions = ctoptions.CTOpts()
 
         self.seed = ''
-
-        self.char_names: list[str] = [
-            'Crono', 'Marle', 'Lucca', 'Robo', 'Frog', 'Ayla', 'Magus',
-            'Epoch'
-        ]
 
     def to_jot_json(self) -> Dict[str, Any]:
         return {
@@ -450,14 +552,13 @@ class Settings:
             "mystery_settings": self.mystery_settings,
             "gameflags": self.gameflags,
             "initial_flags": self.initial_flags,
-            "char_choices": self.char_choices,
             "ro_settings": self.ro_settings,
             "bucket_settings": self.bucket_settings,
+            "char_settings": self.char_settings,
             "tab_settings": self.tab_settings,
             "cosmetic_flags": self.cosmetic_flags,
             "ctoptions": self.ctoptions,
             "seed": self.seed,
-            "char_names": self.char_names,
         }
 
     @staticmethod

--- a/sourcefiles/randosettings.py
+++ b/sourcefiles/randosettings.py
@@ -449,36 +449,46 @@ class CharSettings:
         return {field.name: getattr(self, field.name) for field in fields(self)}
 
 
+@dataclass
 class MysterySettings:
+    '''Settings related to generating mystery seeds.'''
+
+    game_mode_freqs: Dict[GameMode, int] = field(default_factory=dict)
+    item_difficulty_freqs: Dict[Difficulty, int] = field(default_factory=dict)
+    enemy_difficulty_freqs: Dict[Difficulty, int] = field(default_factory=dict)
+    tech_order_freqs: Dict[TechOrder, int] = field(default_factory=dict)
+    shop_price_freqs: Dict[ShopPrices, int] = field(default_factory=dict)
+    flag_prob_dict: Dict[GameFlags, float] = field(default_factory=dict)
+
     def __init__(self):
-        self.game_mode_freqs: dict[GameMode, int] = {
+        self.game_mode_freqs = {
             GameMode.STANDARD: 75,
             GameMode.LOST_WORLDS: 25,
             GameMode.LEGACY_OF_CYRUS: 0,
             GameMode.ICE_AGE: 0,
             GameMode.VANILLA_RANDO: 0
         }
-        self.item_difficulty_freqs: dict[Difficulty, int] = {
+        self.item_difficulty_freqs = {
             Difficulty.EASY: 15,
             Difficulty.NORMAL: 70,
             Difficulty.HARD: 15
         }
-        self.enemy_difficulty_freqs: dict[Difficulty, int] = {
+        self.enemy_difficulty_freqs = {
             Difficulty.NORMAL: 75,
             Difficulty.HARD: 25
         }
-        self.tech_order_freqs: dict[TechOrder, int] = {
+        self.tech_order_freqs = {
             TechOrder.NORMAL: 10,
             TechOrder.BALANCED_RANDOM: 10,
             TechOrder.FULL_RANDOM: 80
         }
-        self.shop_price_freqs: dict[ShopPrices, int] = {
+        self.shop_price_freqs = {
             ShopPrices.NORMAL: 70,
             ShopPrices.MOSTLY_RANDOM: 10,
             ShopPrices.FULLY_RANDOM: 10,
             ShopPrices.FREE: 10
         }
-        self.flag_prob_dict: dict[GameFlags, float] = {
+        self.flag_prob_dict = {
             GameFlags.TAB_TREASURES: 0.10,
             GameFlags.UNLOCKED_MAGIC: 0.5,
             GameFlags.BUCKET_LIST: 0.15,
@@ -494,29 +504,44 @@ class MysterySettings:
         }
 
     def to_jot_json(self) -> Dict[str, JSONType]:
-        attrs = [
-            'game_mode_freqs',
-            'item_difficulty_freqs',
-            'enemy_difficulty_freqs',
-            'tech_order_freqs',
-            'shop_price_freqs',
-            'flag_prob_dict',
-        ]
-        return {attr: {str(k): f for k, f in getattr(self, attr).items()} for attr in attrs}
+        return {
+            field.name: {str(k): freq for k, freq in self[field.name].items()}
+            for field in fields(self)
+        }
 
-    def __str__(self):
-        ret_str = ''
-        ret_str += str(self.game_mode_freqs) + '\n'
-        ret_str += str(self.item_difficulty_freqs) + '\n'
-        ret_str += str(self.enemy_difficulty_freqs) + '\n'
-        ret_str += str(self.tech_order_freqs) + '\n'
-        ret_str += str(self.shop_price_freqs) + '\n'
-        ret_str += str(self.flag_prob_dict) + '\n'
+    def update(self, **items) -> MysterySettings:
+        for attr, updates in items.items():
+            self[attr].update(updates)
+        return self
 
-        return ret_str
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __str__(self) -> str:
+        return '\n'.join(str(self[field.name]) for field in fields(self)) + '\n'
 
 
+
+@dataclass
 class Settings:
+    '''Container for all settings which do not require reading ROM data.'''
+
+    # NOTE: all fields in dataclasses are used to determine object equivalence
+    # that is why initial_flags is intentionally missing from fields list, but initialized in __init__
+    game_mode: GameMode
+    item_difficulty: Difficulty
+    enemy_difficulty: Difficulty
+    techorder: TechOrder
+    shopprices: ShopPrices
+    mystery_settings: MysterySettings
+    gameflags: GameFlags
+    ro_settings: ROSettings
+    bucket_settings: BucketSettings
+    char_settings: CharSettings
+    tab_settings: TabSettings
+    cosmetic_flags: CosmeticFlags
+    ctoptions: ctoptions.CTOpts
+    seed: str
 
     def __init__(self):
 

--- a/sourcefiles/scriptshortener.py
+++ b/sourcefiles/scriptshortener.py
@@ -5,10 +5,8 @@ import ctrom
 import ctenums
 
 import eventcommand
-import eventfunction
 
-from ctevent import CommandNotFoundException
-from eventcommand import EventCommand as EC, FuncSync as FS, Operation as OP
+from eventcommand import EventCommand as EC, FuncSync as FS
 from eventfunction import EventFunction as EF
 
 

--- a/sourcefiles/shops/shoptypes.py
+++ b/sourcefiles/shops/shoptypes.py
@@ -106,7 +106,7 @@ class ShopManager:
         '''Print out all shops with prices from item_db.'''
         print(self.get_spoiler_string(item_db))
 
-    def _jot_json(self):
+    def to_jot_json(self):
         shops_ignored = [
             ctenums.ShopID.EMPTY_12, ctenums.ShopID.EMPTY_14,
             ctenums.ShopID.LAST_VILLAGE_UPDATED

--- a/sourcefiles/techdamagerando.py
+++ b/sourcefiles/techdamagerando.py
@@ -3,7 +3,7 @@ import math
 import random
 from typing import Callable
 
-import ctenums, ctstrings
+import ctstrings
 import cttechtypes as ctt
 import techdb
 

--- a/sourcefiles/techdamagerando.py
+++ b/sourcefiles/techdamagerando.py
@@ -1,7 +1,7 @@
 """Module to randomize tech damage based on assigned mp."""
 import math
 import random
-from typing import Callable
+from typing import Callable, Dict, Union
 
 import ctstrings
 import cttechtypes as ctt
@@ -111,7 +111,7 @@ def modify_effect_header(
     """
 
     # Sketchy math was performed to come up with these.
-    scale_dict: dict[ctt.DamageFormula, Callable[[int], int]] = {
+    scale_dict: Dict[ctt.DamageFormula, Callable[[int], Union[int, float]]] = {
         ctt.DamageFormula.MAGIC: lambda mp: 1.88*mp+4.34,
         ctt.DamageFormula.PC_MELEE: lambda mp: math.sqrt(55.6*mp + 65.8),
         ctt.DamageFormula.PC_AYLA: lambda mp: math.sqrt(62.6*mp + 134),

--- a/sourcefiles/techdamagerando.py
+++ b/sourcefiles/techdamagerando.py
@@ -125,4 +125,3 @@ def modify_effect_header(
     scale_function = scale_dict[formula_type]
     scale_factor = scale_function(new_mp)/scale_function(orig_mp)
     effect_header.power = round(scale_factor*effect_header.power)
-

--- a/sourcefiles/techdb.py
+++ b/sourcefiles/techdb.py
@@ -4,7 +4,6 @@
 #    from hardcoded loop bounds.
 
 from __future__ import annotations
-import copy
 from typing import Optional
 import typing
 
@@ -14,8 +13,7 @@ from byteops import get_record, set_record, \
 import ctenums
 import ctrom
 import ctstrings
-from cttypes import BinaryData, SizedBinaryData
-import cttypes
+from cttypes import SizedBinaryData
 import cttechtypes as ctt
 import pctech
 from techrefs import fix_tech_refs

--- a/sourcefiles/tests/cli/test_arguments.py
+++ b/sourcefiles/tests/cli/test_arguments.py
@@ -79,20 +79,26 @@ def test_args_to_settings(cli_args, expected_settings, parser):
         # set objectives
         (
             (
-                '--bucket-disable-other-go --bucket-objectives-win --bucket-objective-count 3'
+                '--bucket-disable-other-go --bucket-objectives-win --bucket-objective-count 4'
                 ' --bucket-objective-needed-count 2'
             ).split(' ')
             + [
                 '--bucket-objective1=quest_gated',
                 '--bucket-objective2=boss_nogo',
                 '-obj3=50:quest_gated, 30:boss_nogo, 20:recruit_gated',
+                '-obj4=Collect 3 Rocks',
             ],
             rset.BucketSettings(
                 disable_other_go_modes=True,
                 objectives_win=True,
-                num_objectives=3,
+                num_objectives=4,
                 num_objectives_needed=2,
-                hints=['quest_gated', 'boss_nogo', '50:quest_gated, 30:boss_nogo, 20:recruit_gated'],
+                hints=[
+                    'quest_gated',
+                    'boss_nogo',
+                    '50:quest_gated, 30:boss_nogo, 20:recruit_gated',
+                    'Collect 3 Rocks',
+                ],
             ),
         ),
     ],

--- a/sourcefiles/tests/cli/test_arguments.py
+++ b/sourcefiles/tests/cli/test_arguments.py
@@ -15,7 +15,7 @@ import cli.adapters as adp
 import ctoptions
 import randosettings as rset
 
-from randosettings import CosmeticFlags as CF, GameFlags as GF, GameMode as GM
+from randosettings import CosmeticFlags as CF, GameFlags as GF, GameMode as GM, ROFlags as RO
 
 
 @pytest.fixture(scope='session')
@@ -258,9 +258,25 @@ def test_flags_adapters(cli_args, cls, init, expected_flags, parser):
     assert flags == expected_flags, 'Flags do not match expected flags'
 
 
-@pytest.mark.xfail(reason='RO Settings cannot be set by CLI currently')
-def test_ro_settings():
-    assert False
+@pytest.mark.parametrize(
+    'cli_args, expected',
+    [
+        # default
+        ([], rset.ROSettings.from_game_mode(GM.STANDARD)),
+        # boss rando
+        ('-ro --boss-spot-hp'.split(' '), rset.ROSettings.from_game_mode(GM.STANDARD, flags=RO.BOSS_SPOT_HP)),
+        # boss rando LoC
+        ('--mode loc -ro'.split(' '), rset.ROSettings.from_game_mode(GM.LEGACY_OF_CYRUS)),
+        # boss rando Lost Worlds
+        ('--mode lw -ro'.split(' '), rset.ROSettings.from_game_mode(GM.LOST_WORLDS)),
+    ],
+    ids=('default', 'std', 'loc', 'lw'),
+)
+def test_ro_settings(cli_args, expected, parser):
+    args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
+    ro_settings = arguments.args_to_settings(args).ro_settings
+
+    assert ro_settings == expected
 
 
 @pytest.mark.parametrize(

--- a/sourcefiles/tests/cli/test_arguments.py
+++ b/sourcefiles/tests/cli/test_arguments.py
@@ -10,7 +10,7 @@ TechOrder, ShopPrices, character names and settings (CharSettings), BucketSettin
 from __future__ import annotations
 import pytest
 
-import arguments
+import cli.arguments as arguments
 import cli.adapters as adp
 import ctoptions
 import randosettings as rset

--- a/sourcefiles/tests/requirements.txt
+++ b/sourcefiles/tests/requirements.txt
@@ -1,2 +1,3 @@
 flake8>=6.1,<7.0
 pytest>=7.4,<8.0
+pytest-cov>=4.1,<5.0

--- a/sourcefiles/tests/test_arguments.py
+++ b/sourcefiles/tests/test_arguments.py
@@ -35,8 +35,10 @@ def parser():
                 'enemy_difficulty': rset.Difficulty.NORMAL,
                 'techorder': rset.TechOrder.FULL_RANDOM,
                 'shopprices': rset.ShopPrices.NORMAL,
+                # 'mystery_settings': rset.MysterySettings(),
                 'tab_settings': rset.TabSettings(),
                 'char_settings': rset.CharSettings(),
+                'bucket_settings': rset.BucketSettings(),
             },
         ),
         # overriding most non-flag settings
@@ -67,6 +69,40 @@ def test_args_to_settings(cli_args, expected_settings, parser):
 
     for attr, value in expected_settings.items():
         assert getattr(settings, attr) == value
+
+
+@pytest.mark.parametrize(
+    'cli_args, expected',
+    [
+        # default
+        ([], rset.BucketSettings()),
+        # set objectives
+        (
+            (
+                '--bucket-disable-other-go --bucket-objectives-win --bucket-objective-count 3'
+                ' --bucket-objective-needed-count 2'
+            ).split(' ')
+            + [
+                '--bucket-objective1=quest_gated',
+                '--bucket-objective2=boss_nogo',
+                '-obj3=50:quest_gated, 30:boss_nogo, 20:recruit_gated',
+            ],
+            rset.BucketSettings(
+                disable_other_go_modes=True,
+                objectives_win=True,
+                num_objectives=3,
+                num_objectives_needed=2,
+                hints=['quest_gated', 'boss_nogo', '50:quest_gated, 30:boss_nogo, 20:recruit_gated'],
+            ),
+        ),
+    ],
+    ids=('default', 'objectives'),
+)
+def test_bucket_settings(cli_args, expected, parser):
+    args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
+    bset = arguments.args_to_settings(args).bucket_settings
+
+    assert bset == expected
 
 
 @pytest.mark.parametrize(
@@ -214,3 +250,121 @@ def test_flags_adapters(cli_args, cls, init, expected_flags, parser):
 
     assert isinstance(flags, expected_type), f"Flags are not expected type: {expected_type}"
     assert flags == expected_flags, 'Flags do not match expected flags'
+
+
+@pytest.mark.xfail(reason='RO Settings cannot be set by CLI currently')
+def test_ro_settings():
+    assert False
+
+
+@pytest.mark.xfail(reason='mystery defaults are wrong in arguments.py')
+@pytest.mark.parametrize(
+    'cli_args, expected',
+    [
+        # default
+        (
+            [],
+            rset.MysterySettings(),
+        ),
+        # override most game_mode_freqs, make sure LW stays at default
+        (
+            ('--mystery-mode-std=0 --mystery-mode-loc=50 --mystery-mode-ia=20 --mystery-mode-van=5').split(' '),
+            rset.MysterySettings().update(
+                game_mode_freqs={
+                    GM.STANDARD: 0,
+                    GM.LEGACY_OF_CYRUS: 50,
+                    GM.ICE_AGE: 20,
+                    GM.VANILLA_RANDO: 5,
+                }
+            ),
+        ),
+        # override item and enemy difficulties, tech orders, shop prices
+        (
+            (
+                '--mystery-item-easy=10 --mystery-item-norm=40 --mystery-item-hard=50'
+                ' --mystery-enemy-norm=40 --mystery-enemy-hard=60'
+                ' --mystery-tech-norm=0 --mystery-tech-balanced=40 --mystery-tech-rand=60'
+                ' --mystery-prices-norm=40 --mystery-prices-mostly-rand=30 --mystery-prices-rand=20'
+                ' --mystery-prices-free=10'
+            ).split(' '),
+            rset.MysterySettings().update(
+                item_difficulty_freqs={
+                    rset.Difficulty.EASY: 10,
+                    rset.Difficulty.NORMAL: 40,
+                    rset.Difficulty.HARD: 50,
+                },
+                enemy_difficulty_freqs={
+                    rset.Difficulty.NORMAL: 40,
+                    rset.Difficulty.HARD: 60,
+                },
+                tech_order_freqs={
+                    rset.TechOrder.NORMAL: 0,
+                    rset.TechOrder.BALANCED_RANDOM: 40,
+                    rset.TechOrder.FULL_RANDOM: 60,
+                },
+                shop_price_freqs={
+                    rset.ShopPrices.NORMAL: 40,
+                    rset.ShopPrices.MOSTLY_RANDOM: 30,
+                    rset.ShopPrices.FULLY_RANDOM: 20,
+                    rset.ShopPrices.FREE: 10,
+                },
+            ),
+        ),
+        # override flag probs
+        (
+            (
+                '--mystery-flag-bucket-list=0.2 --mystery-flag-boss-scaling=0 --mystery-flag-char-rando=1'
+                ' --mystery-flag-gear-rando=0.6'
+            ).split(' '),
+            rset.MysterySettings().update(
+                flag_prob_dict={
+                    GF.BUCKET_LIST: 0.2,
+                    GF.BOSS_SCALE: 0,
+                    GF.CHAR_RANDO: 1.0,
+                    GF.GEAR_RANDO: 0.6,
+                },
+            ),
+        ),
+    ],
+    ids=('default', 'mode', 'complex', 'flag_prob'),
+)
+def test_mystery_settings(cli_args, expected, parser):
+    args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
+    mystery = arguments.args_to_settings(args).mystery_settings
+
+    assert mystery == expected
+
+
+@pytest.mark.parametrize(
+    'cli_args, expected',
+    [
+        # default
+        (
+            [],
+            rset.TabSettings(),
+        ),
+        # override all tabs settings
+        (
+            (
+                '--min-power-tab=3 --max-power-tab=6 --min-magic-tab=2 --max-magic-tab=4'
+                ' --max-speed-tab=2 --min-speed-tab=2 --tab-scheme=binomial --tab-binom-success=0.7'
+            ).split(' '),
+            rset.TabSettings(
+                power_min=3,
+                power_max=6,
+                magic_min=2,
+                magic_max=4,
+                speed_min=2,
+                speed_max=2,
+                scheme=rset.TabRandoScheme.BINOMIAL,
+                binom_success=0.7,
+            ),
+        ),
+    ],
+    ids=('default', 'complex'),
+)
+def test_tab_settings(cli_args, expected, parser):
+    args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
+    tabset = arguments.args_to_settings(args).tab_settings
+
+    assert tabset == expected

--- a/sourcefiles/tests/test_arguments.py
+++ b/sourcefiles/tests/test_arguments.py
@@ -1,8 +1,21 @@
+'''
+Tests for sourcefiles/arguments.py.
+
+This file ends up exercising and covering a lot of settings-related code across arguments.py,
+randosettings.py, ctoptions.py, bossrandotypes.py, and more, because it tests from passing CLI args through
+the argparse parser to randosettings.args_to_settings creating a Settings object, and makes assertions about
+that which cover testing settings for GameMode, GameFlags, CosmeticFlags, item and enemy difficulty,
+TechOrder, ShopPrices, character names and settings (CharSettings), BucketSettings and more.
+'''
+from __future__ import annotations
 import pytest
 
 import arguments
+import cli.adapters as adp
+import ctoptions
+import randosettings as rset
 
-from randosettings import CosmeticFlags as CF, GameFlags as GF
+from randosettings import CosmeticFlags as CF, GameFlags as GF, GameMode as GM
 
 
 @pytest.fixture(scope='session')
@@ -11,23 +24,124 @@ def parser():
 
 
 @pytest.mark.parametrize(
-    'cli_args, init, expected_flags',
+    'cli_args, expected_settings',
     [
-        (['--fix-glitch', '--zeal-end', '--fast-pendant'], GF(0), GF.FIX_GLITCH | GF.ZEAL_END | GF.FAST_PENDANT),
-        (['--autorun', '--reduce-flashes'], CF(0), CF.AUTORUN | CF.REDUCE_FLASH),
+        # defaults
+        (
+            [],
+            {
+                'game_mode': GM.STANDARD,
+                'item_difficulty': rset.Difficulty.NORMAL,
+                'enemy_difficulty': rset.Difficulty.NORMAL,
+                'techorder': rset.TechOrder.FULL_RANDOM,
+                'shopprices': rset.ShopPrices.NORMAL,
+                'tab_settings': rset.TabSettings(),
+            },
+        ),
+        # overriding most non-flag settings
+        (
+            (
+                '--mode loc --boss-randomization --char-rando --gear-rando --zenan-alt-music'
+                ' --item-difficulty hard --enemy-difficulty hard --tech-order balanced'
+                ' --shop-prices free'
+            ).split(' '),
+            {
+                'game_mode': GM.LEGACY_OF_CYRUS,
+                'gameflags': GF.BOSS_RANDO | GF.CHAR_RANDO | GF.GEAR_RANDO,
+                'cosmetic_flags': CF.ZENAN_ALT_MUSIC,
+                'item_difficulty': rset.Difficulty.HARD,
+                'enemy_difficulty': rset.Difficulty.HARD,
+                'techorder': rset.TechOrder.BALANCED_RANDOM,
+                'shopprices': rset.ShopPrices.FREE,
+            },
+        ),
+    ],
+    ids=('defaults', 'complex'),
+)
+def test_args_to_settings(cli_args, expected_settings, parser):
+    args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
+    settings = arguments.args_to_settings(args)
+
+    assert isinstance(settings, rset.Settings), f"Wrong type for settings: {type(settings)}"
+
+    for attr, value in expected_settings.items():
+        assert getattr(settings, attr) == value
+
+
+@pytest.mark.parametrize(
+    'cli_args, expected_settings',
+    [
+        # default
+        (
+            [],
+            {
+                'battle_speed': 4,
+                'save_menu_cursor': 0,
+                'skill_item_info': 1,
+                'menu_background': 0,
+                'battle_msg_speed': 4,
+                'save_battle_cursor': 0,
+                'save_tech_cursor': 1,
+                'battle_gauge_style': 1,
+            },
+        ),
+        # override all ctoptions
+        (
+            (
+                '--battle-speed=1 --save-menu-cursor --skill-item-info-off --background=3'
+                ' --battle-msg-speed 1 --save-battle-cursor --save-skill-cursor-off'
+                ' --battle-gauge-style 2'
+            ).split(' '),
+            {
+                'battle_speed': 0,
+                'save_menu_cursor': 1,
+                'skill_item_info': 0,
+                'menu_background': 2,
+                'battle_msg_speed': 0,
+                'save_battle_cursor': 1,
+                'save_tech_cursor': 0,
+                'battle_gauge_style': 2,
+            },
+        ),
+    ],
+    ids=('default', 'complex'),
+)
+def test_ctoptions_settings(cli_args, expected_settings, parser):
+    args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
+    ctopts = arguments.args_to_settings(args).ctoptions
+
+    assert isinstance(ctopts, ctoptions.CTOpts), f"Wrong type: {type(ctopts)}"
+
+    for attr, value in expected_settings.items():
+        assert getattr(ctopts, attr) == value
+
+
+@pytest.mark.parametrize(
+    'cli_args, cls, init, expected_flags',
+    [
+        # game flags
+        (
+            ['--fix-glitch', '--zeal-end', '--fast-pendant'],
+            adp.GameFlagsAdapter,
+            None,
+            GF.FIX_GLITCH | GF.ZEAL_END | GF.FAST_PENDANT,
+        ),
+        # cosmetic flags
+        (['--autorun', '--reduce-flashes'], adp.CosmeticFlagsAdapter, None, CF.AUTORUN | CF.REDUCE_FLASH),
+        # starting with initial flags and adding more game flags from CLI args
         (
             ['--chronosanity', '--unlocked-skyways'],
+            adp.GameFlagsAdapter,
             GF.FIX_GLITCH | GF.FAST_TABS,
             GF.FIX_GLITCH | GF.FAST_TABS | GF.CHRONOSANITY | GF.UNLOCKED_SKYGATES,
         ),
     ],
     ids=('gameflags', 'cosmetic_flags', 'init'),
 )
-def test_fill_flags(cli_args, init, expected_flags, parser):
+def test_flags_adapters(cli_args, cls, init, expected_flags, parser):
     args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
-    val_dict = vars(args)
 
-    flags = arguments.fill_flags(val_dict, init)
+    flags = cls.to_setting(args, init=init)
     expected_type = type(expected_flags)
 
     assert isinstance(flags, expected_type), f"Flags are not expected type: {expected_type}"

--- a/sourcefiles/tests/test_arguments.py
+++ b/sourcefiles/tests/test_arguments.py
@@ -1,0 +1,34 @@
+import pytest
+
+import arguments
+
+from randosettings import CosmeticFlags as CF, GameFlags as GF
+
+
+@pytest.fixture(scope='session')
+def parser():
+    return arguments.get_parser()
+
+
+@pytest.mark.parametrize(
+    'cli_args, init, expected_flags',
+    [
+        (['--fix-glitch', '--zeal-end', '--fast-pendant'], GF(0), GF.FIX_GLITCH | GF.ZEAL_END | GF.FAST_PENDANT),
+        (['--autorun', '--reduce-flashes'], CF(0), CF.AUTORUN | CF.REDUCE_FLASH),
+        (
+            ['--chronosanity', '--unlocked-skyways'],
+            GF.FIX_GLITCH | GF.FAST_TABS,
+            GF.FIX_GLITCH | GF.FAST_TABS | GF.CHRONOSANITY | GF.UNLOCKED_SKYGATES,
+        ),
+    ],
+    ids=('gameflags', 'cosmetic_flags', 'init'),
+)
+def test_fill_flags(cli_args, init, expected_flags, parser):
+    args = parser.parse_args(cli_args + ['-i', 'ct.rom'])
+    val_dict = vars(args)
+
+    flags = arguments.fill_flags(val_dict, init)
+    expected_type = type(expected_flags)
+
+    assert isinstance(flags, expected_type), f"Flags are not expected type: {expected_type}"
+    assert flags == expected_flags, 'Flags do not match expected flags'

--- a/sourcefiles/tests/test_arguments.py
+++ b/sourcefiles/tests/test_arguments.py
@@ -35,7 +35,7 @@ def parser():
                 'enemy_difficulty': rset.Difficulty.NORMAL,
                 'techorder': rset.TechOrder.FULL_RANDOM,
                 'shopprices': rset.ShopPrices.NORMAL,
-                # 'mystery_settings': rset.MysterySettings(),
+                'mystery_settings': rset.MysterySettings(),
                 'tab_settings': rset.TabSettings(),
                 'char_settings': rset.CharSettings(),
                 'bucket_settings': rset.BucketSettings(),
@@ -257,7 +257,6 @@ def test_ro_settings():
     assert False
 
 
-@pytest.mark.xfail(reason='mystery defaults are wrong in arguments.py')
 @pytest.mark.parametrize(
     'cli_args, expected',
     [

--- a/sourcefiles/tests/test_jotjson.py
+++ b/sourcefiles/tests/test_jotjson.py
@@ -1,0 +1,21 @@
+import json
+import pytest
+
+import jotjson
+import randosettings as rset
+
+
+@pytest.fixture(scope='session')
+def settings():
+    GF = rset.GameFlags
+    settings = rset.Settings()
+    settings.gameflags = GF.FIX_GLITCH | GF.EPOCH_FAIL
+    settings.bucket_settings.objectives_win = True
+    settings.char_choices[5] == [5]
+    settings.tab_settings.scheme = scheme = rset.TabRandoScheme.BINOMIAL
+    return settings
+
+
+def test_json_encode_settings(settings):
+    data = json.dumps(settings, cls=jotjson.JOTJSONEncoder)
+    assert data, 'Failed to encode settings into JSON.'

--- a/sourcefiles/tests/test_jotjson.py
+++ b/sourcefiles/tests/test_jotjson.py
@@ -11,7 +11,7 @@ def settings():
     settings = rset.Settings()
     settings.gameflags = GF.FIX_GLITCH | GF.EPOCH_FAIL
     settings.bucket_settings.objectives_win = True
-    settings.char_choices[5] == [5]
+    settings.char_settings.choices[5] == [5]
     settings.tab_settings.scheme = scheme = rset.TabRandoScheme.BINOMIAL
     return settings
 

--- a/sourcefiles/tests/test_objectivehints.py
+++ b/sourcefiles/tests/test_objectivehints.py
@@ -1,0 +1,12 @@
+import objectivehints as obhint
+
+
+def test_objective_hint_aliases_valid():
+    '''Check that all obhint aliases map to valid hints.'''
+    obhint_aliases = obhint.get_objective_hint_aliases()
+
+    assert obhint_aliases, 'Failed to get objective hint aliases'
+
+    for alias in obhint_aliases.keys():
+        valid, err = obhint.is_hint_valid(alias)
+        assert valid, f"Invalid hint alias ({alias}): {err}"

--- a/sourcefiles/tests/test_randosettings.py
+++ b/sourcefiles/tests/test_randosettings.py
@@ -145,3 +145,30 @@ def test_fix_flag_conflicts_unfixable(settings):
     with pytest.raises(ValueError) as ex:
         settings.fix_flag_conflicts()
     assert 'fix flag conflicts' in str(ex)
+
+
+@pytest.mark.parametrize('mode', list(rset.GameMode), ids=[str(mode) for mode in list(rset.GameMode)])
+def test_ro_settings_spots(mode):
+    '''Check that Boss Rando spots selected from game mode.'''
+    roset = rset.ROSettings.from_game_mode(mode)
+
+    assert roset.spots, f'Missing boss rando spots for mode: {mode}'
+    assert roset.bosses, f'Missing boss rando bosses for mode: {mode}'
+
+
+@pytest.mark.parametrize(
+    'preset',
+    [
+        rset.Settings.get_race_presets,
+        rset.Settings.get_new_player_presets,
+        rset.Settings.get_lost_worlds_presets,
+        rset.Settings.get_hard_presets,
+        rset.Settings.get_tourney_early_preset,
+        rset.Settings.get_tourney_top8_preset,
+    ],
+    ids=('race', 'new_player', 'lost_worlds', 'hard', 'tourney_early', 'tourney_top8'),
+)
+def test_settings_from_preset(preset):
+    '''Check all presets can be parsed into Settings.'''
+    settings = preset()
+    assert settings

--- a/sourcefiles/tests/test_randosettings.py
+++ b/sourcefiles/tests/test_randosettings.py
@@ -1,6 +1,7 @@
 import pytest
 import randosettings as rset
 
+from bossrandotypes import BossID
 from randosettings import GameFlags as _GF
 from randosettings import GameMode as _GM
 
@@ -145,6 +146,20 @@ def test_fix_flag_conflicts_unfixable(settings):
     with pytest.raises(ValueError) as ex:
         settings.fix_flag_conflicts()
     assert 'fix flag conflicts' in str(ex)
+
+
+@pytest.mark.parametrize('mode', [rset.GameMode.STANDARD, rset.GameMode.LOST_WORLDS], ids=('standard', 'lostworlds'))
+def test_ro_settings_bosses(mode):
+    '''Check that Boss Rando bosses can be specified in ROSettings.
+
+    Check can specify a partial list of bosses and they are included in ROSettings.
+    The boss list is padded out with random other bosses to match number of spots.
+    '''
+    bosses = [BossID.MAGUS_NORTH_CAPE, BossID.YAKRA_XIII, BossID.NIZBEL_2, BossID.DALTON_PLUS]
+    roset = rset.ROSettings.from_game_mode(mode, bosses=bosses)
+
+    assert len(roset.spots) == len(roset.bosses)
+    assert bosses == roset.bosses[: len(bosses)], 'ROSettings bosses does not start with expected bosses'
 
 
 @pytest.mark.parametrize('mode', list(rset.GameMode), ids=[str(mode) for mode in list(rset.GameMode)])

--- a/sourcefiles/treasures/delete_treasurewriter.py
+++ b/sourcefiles/treasures/delete_treasurewriter.py
@@ -25,7 +25,7 @@ class Treasure(abc.ABC):
     def __init__(self, reward: RewardType = ctenums.ItemID.MOP):
         self.reward = reward
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return str(self.reward)
 
     @abc.abstractmethod

--- a/sourcefiles/treasures/delete_treasurewriter.py
+++ b/sourcefiles/treasures/delete_treasurewriter.py
@@ -8,16 +8,12 @@ import abc
 import typing
 
 import byteops
-import ctevent
 import ctenums
 import ctrom
 import cttypes as ctt
 
-import eventcommand
-import eventfunction
 
-from eventcommand import EventCommand as EC, FuncSync as FS, Operation as OP
-from eventfunction import EventFunction as EF
+from eventcommand import EventCommand as EC
 
 
 RewardType = typing.Union[ctenums.ItemID, int]

--- a/sourcefiles/treasures/treasuretypes.py
+++ b/sourcefiles/treasures/treasuretypes.py
@@ -17,10 +17,8 @@ import ctstrings
 import cttypes as ctt
 
 import eventcommand
-import eventfunction
 
-from eventcommand import EventCommand as EC, FuncSync as FS, Operation as OP
-from eventfunction import EventFunction as EF
+from eventcommand import EventCommand as EC
 
 
 RewardType = typing.Union[ctenums.ItemID, int]

--- a/sourcefiles/treasures/treasuretypes.py
+++ b/sourcefiles/treasures/treasuretypes.py
@@ -31,7 +31,7 @@ class Treasure(abc.ABC):
     def __init__(self, reward: RewardType = ctenums.ItemID.MOP):
         self.reward = reward
 
-    def _jot_json(self):
+    def to_jot_json(self):
         return str(self.reward)
 
     @abc.abstractmethod

--- a/sourcefiles/treasures/treasuretypes.py
+++ b/sourcefiles/treasures/treasuretypes.py
@@ -276,7 +276,7 @@ class ScriptTreasure(Treasure):
             reward: RewardType,
             orig_gold_amt: typing.Optional[int] = None):
 
-        if type(reward) == ctenums.ItemID:
+        if isinstance(reward, ctenums.ItemID):
             if reward == ctenums.ItemID.NONE:
                 repl_str = 'Nothing'
             else:

--- a/sourcefiles/treasures/treasurewriter.py
+++ b/sourcefiles/treasures/treasurewriter.py
@@ -272,4 +272,3 @@ def find_script_ptrs(ptr_list):
         chest_index = (ptr-0x35f404)//4
         if 0 > chest_index or chest_index > 0xF8:
             print(f"{ptr:06X}")
-

--- a/sourcefiles/treasures/treasurewriter.py
+++ b/sourcefiles/treasures/treasurewriter.py
@@ -231,7 +231,7 @@ def ptr_to_enum(ptr_list):
     tdict = config.treasure_assign_dict
 
     treasureids = [x for x in tdict.keys()
-                   if type(tdict[x]) == cfg.ChestTreasure
+                   if isinstance(tdict[x], cfg.ChestTreasure)
                    and tdict[x].chest_index in chestid]
 
     used_ids = [tdict[x].chest_index for x in treasureids]


### PR DESCRIPTION
This PR is a set of what I think are relatively low-risk changes as a precursor to [adding support for "presets"](https://github.com/coffeemancy/jetsoftime/pull/5): JSON files that can be used with the CLI and web GUI to populate all aspects of a `Settings` object to generate a seed.

The overall vision is to make it easy to create/share/test presets, even by non-developers, and to have a consistent data interface for the CLI and web UI, which in the future could drive other tools, such as a seed-generating Discord bot which makes API requests to the web UI (using the preset  JSON format).

The intention is to reduce risk via having a high level of type-checking and unit testing of the changes.

I have tried to group changes and order the commits to hopefully make reviewing this larger PR a bit easier (than just looking at all files changed in one go).

## Updates

### User-Facing

Features:

* The objective hint aliases in the TK GUI and web UI can now also be used in the CLI

Bugfixes:

* CLI now correctly supports setting/overriding shop prices, tab settings
* CLI uses and displays correct defaults for bucket, tab, and mystery settings
* CLI now honors character choices and allows specifying by name or "not" (`--frog-choices=not magus`)
* Fixed objective hints for "collect X rocks" / "collect X fragments" to be in correct format in TK GUI

Minor:

* All CLI args now consistently use "kebab-case" (hyphens, no underscores)
* Legacy Boss Rando spot placement option is accessible like in web UI (`--legacy-boss-placement`)
* Boss rando flags (ROFlags) are now displayed separately in the spoiler
* Boss rando: if you clear location spots (such that they are determined by game mode), and you only specify a partial list of bosses, remaining bosses will be chosen randomly to fill remaining spots (instead of crashing randomizer; effectively this forces the partial list of bosses into a seed) (this is technically possible to configure currently in TK GUI, but is more an outcome of defensive coding than intentional feature, per se)

### Developer-Facing

Major / Web UI-Impacting:

* Combining `char_names` and `char_choices` into a single `CharSettings` dataclass (similar to handling of bucket settings, others), and moved `parse_choices` into that class, so can specify things like "not crono" on the CLI (or in preset files in follow-on work)
* Move objective hint aliases out of `bucketgui.py` into accessible, unit-tested hints in `objectivehints.py`  (these will be directly consumed by web UI to avoid repetition/errors there)
* Settings classes now have public `to_jot_json` method (unit tested) (a `from_jot_json` will be added in follow-on PR for preset support)
* Moved `_forced_*_dict` under `ForcedFlags` container class (ease of re-use in web UI; these will drive dynamic restrictions on flags in the web UI)
* Boss Rando flags have been consolidated as `ROFlags` only under `Settings.ro_settings.flags` (this removes `GameFlags.BOSS_SPOT_HP`, consolidating on `ROFlags.BOSS_SPOT_HP` -- seems to be direction that [Boss Rando refactoring work](https://github.com/Pseudoarc/jetsoftime/commit/5f9e6ab4c286fff0a354eca6ee39615410f6310d#diff-f3cfc4ba05d2ac4be9660f2fcbb65e260717c1f5f10c69b3fc313907237224fc) was headed)

Exclusively CLI-Impacting:

* CLI refactoring overhaul with high level of unit-test coverage for all flags/features driving creation of `randosettings.Settings` (85%+ coverage)
* Moving `arguments.py` -> `cli/arguments.py` and introducing `ArgumentGroup` protocol/implementation classes for generating arguments
* Defaults for arguments no longer need to be specified in multiple places (CLI pulls defaults correctly from Settings classes)
* `cli/adapters.py` with `SettingsAdapter` protocol/implementation classes for converting from CLI arguments to `randosettings.Settings` objects

Minor:

* Flake8 fixups (`isinstance`, rm bare `except`, rm unused imports, some whitespace)
* Coverage reporting for `pytest`
* Type fixups to enable using `mypy` for type-checking locally (not included in tests, yet, didn't want to stuff that on anyone, just for local dev)
* Significant bump in overall code coverage via unit testing with `pytest` achieving about 3% overall coverage now (up from about 25% prior to this PR), mostly around `args_to_settings` / CLI creation of `Settings`, `randosettings`, but enabling path for more with presets work
* All paths to pickles, patches, flux, names.txt use actual paths relative to code, instead of relative to CWD (no longer using "./" paths) (this makes it easier to drop to python/pdb, especially when cross-developing web UI)

## Testing

* [Github actions](https://github.com/coffeemancy/jetsoftime/actions/runs/6214076454) :heavy_check_mark: 

A lot of the testing for these changes is covered through type-checking with `mypy` and then adding extensive `pytest` for the CLI changes (mostly to `args_to_settings` generation and the classes in `randosettings.py`).

However, both the CLI and TK GUI were also spot checked with seed generation (creating seeds with different settings, including bucket list testing with CLI, and mystery seeds with TK GUI).

### Pytest Coverage

Before and after:

|    |Before|After| Diff |
|---|---|---|---|
| covered_lines | 5856 | 6685 | +820 |
| missing_lines | 14498 | 14038 | -460|

Noticeable on certain files:

* `arguments.py`: 16% -> `cli/*`: 95-100%
* `ctoptions.py`: 35% -> 40%
* `objectivehints.py`: 8% (248 lines missing) -> 87% (37 lines missing) (because of moving out of bucketgui.py, testing hints, and fixing buckets and testing it in CLI)

## Notes

* I know this PR is pretty big, but a lot of it is moving stuff around and refactorings. Hopefully the organized commits, type-checking, and unit tests makes it easier to review.
* I've already got the `--presets` working with https://github.com/coffeemancy/jetsoftime/pull/5, even working locally with `ctjot_web_generator` (you can upload a preset JSON and it selects everything in the GUI). However, I thought that was a bit too big of a change, and wanted to break out and get in these changes first, was the thinking.
* There is an intermediary PR in flight on web GUI updating to drive UI from data to support this: https://github.com/Anguirel86/ctjot_web_generator/pull/20
* There has been some discussion about moving current Beta to stable. I think it is fine to hold off on these changes (or at least the addition of preset support in a follow-on PR) until that happens; definitely not trying to create more work for folks holding that off. That being said, this PR did uncover several bugs in the CLI (and the objective hints in the TK GUI), so if there isn't a rush to move current beta to stable, this could be considered useful.