### PR TITLE
Ice Age chronosanity location fix

### DIFF
--- a/sourcefiles/logicfactory.py
+++ b/sourcefiles/logicfactory.py
@@ -1734,8 +1734,9 @@ class ChronosanityIceAgeGameConfig(ChronosanityGameConfig):
     def initLocations(self):
         ChronosanityGameConfig.initLocations(self)
 
-        # For Chronosanity, just remove the Woe group.
+        # For Chronosanity, just remove the Woe group and Magic Cave
         self.locationGroups.remove(self.getLocationGroup('Darkages'))
+        self.locationGroups.remove(self.getLocationGroup('Magic Cave'))
 
 
 # Note: Accessing MtWoe is the same as accessing EoT in current logic.


### PR DESCRIPTION
Remove Magic Cave as a possible location in the Ice Age game mode when chronosanity is enabled.